### PR TITLE
Fixes to animation system

### DIFF
--- a/MRETestBed/Assets/Scenes/HelloWorld.unity
+++ b/MRETestBed/Assets/Scenes/HelloWorld.unity
@@ -437,4 +437,3 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 30.743002, y: -102.796005, z: -58.797005}
-  

--- a/MRETestBed/Assets/Scenes/HelloWorld.unity
+++ b/MRETestBed/Assets/Scenes/HelloWorld.unity
@@ -437,3 +437,4 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 30.743002, y: -102.796005, z: -58.797005}
+  

--- a/MRETestBed/Assets/Scenes/HelloWorld.unity
+++ b/MRETestBed/Assets/Scenes/HelloWorld.unity
@@ -200,7 +200,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c08c6a44e83210c48bc797284376afc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MREURL: ws://mre-hello-world.azurewebsites.net
+  MREURL: ws://127.0.0.1:3901
   SessionID: foo
   AppID: solar-system-app
   AutoStart: 0
@@ -210,7 +210,7 @@ MonoBehaviour:
   UserGameObject: {fileID: 276664683}
   SerifFont: {fileID: 12800000, guid: 70daac12c1ea27648bb12988a837e0a6, type: 3}
   SansSerifFont: {fileID: 12800000, guid: 7a83a8b8d6810db4aa50e3bde952e2c4, type: 3}
-  DefaultPrimMaterial: {fileID: 2100000, guid: 265cb5b418966a64ea212597d469fa33, type: 2}
+  DefaultPrimMaterial: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
 --- !u!114 &1141388992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1942328352}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -2.72, z: 0}
+  m_LocalPosition: {x: 0, y: -0.6, z: 0}
   m_LocalScale: {x: 200, y: 1, z: 200}
   m_Children: []
   m_Father: {fileID: 0}

--- a/MRETestBed/Assets/Scenes/HelloWorld.unity
+++ b/MRETestBed/Assets/Scenes/HelloWorld.unity
@@ -200,7 +200,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c08c6a44e83210c48bc797284376afc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MREURL: ws://127.0.0.1:3901
+  MREURL: ws://mre-hello-world.azurewebsites.net
   SessionID: foo
   AppID: solar-system-app
   AutoStart: 0
@@ -210,7 +210,7 @@ MonoBehaviour:
   UserGameObject: {fileID: 276664683}
   SerifFont: {fileID: 12800000, guid: 70daac12c1ea27648bb12988a837e0a6, type: 3}
   SansSerifFont: {fileID: 12800000, guid: 7a83a8b8d6810db4aa50e3bde952e2c4, type: 3}
-  DefaultPrimMaterial: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  DefaultPrimMaterial: {fileID: 2100000, guid: 265cb5b418966a64ea212597d469fa33, type: 2}
 --- !u!114 &1141388992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1942328352}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.6, z: 0}
+  m_LocalPosition: {x: 0, y: -2.72, z: 0}
   m_LocalScale: {x: 200, y: 1, z: 200}
   m_Children: []
   m_Father: {fileID: 0}

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -908,6 +908,13 @@ namespace MixedRealityExtension.App
                 .ResumeAnimation(payload.AnimationName);
         }
 
+        [CommandHandler(typeof(ResetAnimation))]
+        private void OnResetAnimation(ResetAnimation payload)
+        {
+            _actorManager.FindActor(payload.ActorId)?.GetOrCreateActorComponent<AnimationComponent>()
+                .ResetAnimation(payload.AnimationName);
+        }
+
         [CommandHandler(typeof(SyncAnimations))]
         private void OnSyncAnimations(SyncAnimations payload)
         {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -516,10 +516,11 @@ namespace MixedRealityExtension.Core
                 return false;
             }
 
-            // Sync all updates to the app if we're operating in a peer-authoritative model and we're the authoritative peer, unless the actor is currently animating.
+            // Sync all updates to the app if we're operating in a peer-authoritative model and we're the authoritative peer.
             if (App.OperatingModel == OperatingModel.PeerAuthoritative && App.IsAuthoritativePeer)
             {
-                return !Animating;
+                // return !Animating;
+                return true;
             }
 
             // Sync this update to the app if we're operating in a server-authoritative model and the app has registered interest in this setting.

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -519,7 +519,6 @@ namespace MixedRealityExtension.Core
             // Sync all updates to the app if we're operating in a peer-authoritative model and we're the authoritative peer.
             if (App.OperatingModel == OperatingModel.PeerAuthoritative && App.IsAuthoritativePeer)
             {
-                // return !Animating;
                 return true;
             }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -188,7 +188,7 @@ namespace MixedRealityExtension.Core.Components
             {
                 if (animation[animationName] != null)
                 {
-                    if (animation[animationName].speed > 0)
+                    if (animation[animationName].speed != 0)
                     {
                         if (_hasRootMotion.TryGetValue(animationName, out bool dictionaryValue) && dictionaryValue)
                         {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -170,7 +170,10 @@ namespace MixedRealityExtension.Core.Components
                         ApplyRootMotion(animation[animationName].clip, animation[animationName].time, animationTime ?? 0f);
                     }
 
-                    // animation[animationName].time = animationTime ?? 0;
+                    if (animationTime.HasValue)
+                    {
+                        animation[animationName].time = animationTime.Value;
+                    }
                     animation[animationName].speed = 0f;
 
                     AnimationStopped(animationName, animation[animationName].time);


### PR DESCRIPTION
Developing the chess app exposed a few animation bugs:
1. Actor transform was not getting sent to the app when animating. Transforms should not be synchronized to other clients when animating, but the app should still get updates if you've subscribed to transform changes on the actor.
2. ResetAnimation handler wasn't implemented on the client.
3. Animation enable/disable is now controlled by setting the animation speed to 1 or 0. This allows us to set the animation time even when the animation isn't playing. This was necessary for ResetAnimation to work.