### PR TITLE
[Unity] Actor patching improvements

### DIFF
--- a/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
@@ -428,6 +428,10 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 11400000, guid: d67a625648c6fd743a7451d9b6d5357a, type: 2}
+      propertyPath: m_WalkSpeed
+      value: 20
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d67a625648c6fd743a7451d9b6d5357a, type: 2}
   m_IsPrefabParent: 0

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
@@ -26,7 +26,7 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// <summary>
         /// The arguments to the remote procedure call.
         /// </summary>
-        public JArray Args { get; set; }
+        public JArray Args { get; set; } = new JArray();
     }
 
     /// <summary>


### PR DESCRIPTION
An optimization on the Node side exposed an unsafe assumption in the client's handling of RPC messages.

Also: Sped up walk speed in the Functional Test scene.
