### PR TITLE
Fix animation synchronization

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/IRigidBody.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/IRigidBody.cs
@@ -122,16 +122,6 @@ namespace MixedRealityExtension.Core.Interfaces
         bool UseGravity { get; }
 
         /// <summary>
-        /// Gets the position of the rigid body.
-        /// </summary>
-        MWVector3 Position { get; }
-
-        /// <summary>
-        /// Gets the rotation of the rigid body.
-        /// </summary>
-        MWQuaternion Rotation { get; }
-
-        /// <summary>
         /// Gets the constraint flags applied to the rigid body.
         /// </summary>
         MRERigidBodyConstraints ConstraintFlags { get; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/RigidBody.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/RigidBody.cs
@@ -41,12 +41,6 @@ namespace MixedRealityExtension.Core
         public bool UseGravity { get; set; }
 
         /// <inheritdoc />
-        public MWVector3 Position { get; set; }
-
-        /// <inheritdoc />
-        public MWQuaternion Rotation { get; set; }
-
-        /// <inheritdoc />
         public MRERigidBodyConstraints ConstraintFlags { get; set; }
 
         internal RigidBody(Rigidbody rigidbody, Transform sceneRoot)
@@ -145,8 +139,6 @@ namespace MixedRealityExtension.Core
             DetectCollisions = rigidbody.detectCollisions;
             CollisionDetectionMode = (MRECollisionDetectionMode)Enum.Parse(typeof(MRECollisionDetectionMode), rigidbody.collisionDetectionMode.ToString());
             UseGravity = rigidbody.useGravity;
-            Position = _sceneRoot.InverseTransformPoint(rigidbody.position).ToMWVector3();
-            Rotation = (Quaternion.Inverse(_sceneRoot.rotation) * rigidbody.rotation).ToMWQuaternion();
             ConstraintFlags = (MRERigidBodyConstraints)Enum.Parse(typeof(MRERigidBodyConstraints), rigidbody.constraints.ToString());
         }
 
@@ -159,8 +151,6 @@ namespace MixedRealityExtension.Core
             _rigidbody.detectCollisions = _rigidbody.detectCollisions.GetPatchApplied(DetectCollisions.ApplyPatch(patch.DetectCollisions));
             _rigidbody.collisionDetectionMode = _rigidbody.collisionDetectionMode.GetPatchApplied(CollisionDetectionMode.ApplyPatch(patch.CollisionDetectionMode));
             _rigidbody.useGravity = _rigidbody.useGravity.GetPatchApplied(UseGravity.ApplyPatch(patch.UseGravity));
-            _rigidbody.position = _rigidbody.position.GetPatchApplied(_sceneRoot.TransformPoint(Position.ApplyPatch(patch.Position).ToVector3()));
-            _rigidbody.rotation = _sceneRoot.rotation * _rigidbody.rotation.GetPatchApplied(Rotation.ApplyPatch(patch.Rotation));
             _rigidbody.constraints = (RigidbodyConstraints)((int)_rigidbody.constraints).GetPatchApplied((int)ConstraintFlags.ApplyPatch(patch.ConstraintFlags));
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/PatchingUtils.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/PatchingUtils.cs
@@ -148,8 +148,6 @@ namespace MixedRealityExtension.Patching
                 DetectCollisions = GeneratePatch(_old.DetectCollisions, _new.detectCollisions),
                 Mass = GeneratePatch(_old.Mass, _new.mass),
                 UseGravity = GeneratePatch(_old.UseGravity, _new.useGravity),
-                Position = GeneratePatch(_old.Position, sceneRoot.InverseTransformPoint(_new.position)),
-                Rotation = GeneratePatch(_old.Rotation, Quaternion.Inverse(sceneRoot.rotation) * _new.rotation),
             };
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
@@ -35,12 +35,6 @@ namespace MixedRealityExtension.Patching.Types
         public bool? UseGravity { get; set; }
 
         [PatchProperty]
-        public Vector3Patch Position { get; set; }
-
-        [PatchProperty]
-        public QuaternionPatch Rotation { get; set; }
-
-        [PatchProperty]
         public MRERigidBodyConstraints[] Constraints
         {
             get
@@ -111,8 +105,6 @@ namespace MixedRealityExtension.Patching.Types
             DetectCollisions = rigidbody.detectCollisions;
             CollisionDetectionMode = (MRECollisionDetectionMode)Enum.Parse(typeof(MRECollisionDetectionMode), rigidbody.collisionDetectionMode.ToString());
             UseGravity = rigidbody.useGravity;
-            Position = new Vector3Patch(sceneRoot.InverseTransformPoint(rigidbody.position));
-            Rotation = new QuaternionPatch(Quaternion.Inverse(sceneRoot.rotation) * rigidbody.rotation);
             ConstraintFlags = (MRERigidBodyConstraints)Enum.Parse(typeof(MRERigidBodyConstraints), rigidbody.constraints.ToString());
         }
 


### PR DESCRIPTION
The client was being too smart about when to process the sync-animations message. If the server sent it, trust it knows what it's doing.

Also: Removed position and rotation fields from the rigid body patch. These fields already exist in the transform.