### PR TITLE
[Unity] Create materials and textures directly

### DIFF
--- a/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
@@ -851,6 +851,7 @@ MonoBehaviour:
     type: 2}
   MREURL: ws://localhost:3901
   testNames:
+  - asset-early-assignment-test
   - asset-preload-test
   - clock-sync-test
   - gltf-animation-test
@@ -862,6 +863,7 @@ MonoBehaviour:
   - look-at-test
   - mutable-asset-test
   - primitives-test
+  - reparent-test
   - rigid-body-test
   - text-test
   - user-test

--- a/MRETestBed/Assets/TestBed Assets/Scripts/MREComponent.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/MREComponent.cs
@@ -88,9 +88,9 @@ public class MREComponent : MonoBehaviour
         if (!_apiInitialized)
         {
             MREAPI.InitializeAPI(
+                DefaultPrimMaterial,
                 behaviorFactory: new BehaviorFactory(),
                 textFactory: new MWTextFactory(SerifFont, SansSerifFont),
-                primitiveFactory: new MWPrimitiveFactory(DefaultPrimMaterial),
                 libraryFactory: new ResourceFactory(),
                 assetCache: new AssetCache(new GameObject("MRE Asset Cache")),
                 logger: new MRELogger());

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -43,7 +43,7 @@ namespace MixedRealityExtension.API
             AppsAPI.DefaultMaterial = defaultMaterial;
             AppsAPI.BehaviorFactory = behaviorFactory;
             AppsAPI.TextFactory = textFactory ?? throw new ArgumentException($"{nameof(textFactory)} cannot be null");
-            AppsAPI.PrimitiveFactory = primitiveFactory;
+            AppsAPI.PrimitiveFactory = primitiveFactory ?? new MWPrimitiveFactory();
             AppsAPI.LibraryResourceFactory = libraryFactory;
             AppsAPI.AssetCache = assetCache ?? new AssetCache();
             AppsAPI.GLTFImporterFactory = gltfImporterFactory ?? new GLTFImporterFactory();

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -22,6 +22,7 @@ namespace MixedRealityExtension.API
         /// <summary>
         /// Initializes the Mixed Reality Extension SDK API.
         /// </summary>
+        /// <param name="defaultMaterial">The material template used for all SDK-spawned meshes.</param>
         /// <param name="behaviorFactory">The behavior factory to use within the runtime.</param>
         /// <param name="textFactory">The text factory to use within the runtime.</param>
         /// <param name="primitiveFactory">The primitive factory to use within the runtime.</param>
@@ -30,6 +31,7 @@ namespace MixedRealityExtension.API
         /// <param name="gltfImporterFactory">The glTF loader factory. Uses default GLTFSceneImporter if omitted.</param>
         /// <param name="logger">The logger to be used by the MRE SDK.</param>
         public static void InitializeAPI(
+            UnityEngine.Material defaultMaterial,
             IBehaviorFactory behaviorFactory = null,
             ITextFactory textFactory = null,
             IPrimitiveFactory primitiveFactory = null,
@@ -38,6 +40,7 @@ namespace MixedRealityExtension.API
             IGLTFImporterFactory gltfImporterFactory = null,
             IMRELogger logger = null)
         {
+            AppsAPI.DefaultMaterial = defaultMaterial;
             AppsAPI.BehaviorFactory = behaviorFactory;
             AppsAPI.TextFactory = textFactory ?? throw new ArgumentException($"{nameof(textFactory)} cannot be null");
             AppsAPI.PrimitiveFactory = primitiveFactory;
@@ -72,6 +75,11 @@ namespace MixedRealityExtension.API
     public class MREAppsAPI
     {
         private AppManager _apps = new AppManager();
+
+        /// <summary>
+        /// The material template used for all SDK-spawned materials.
+        /// </summary>
+        public UnityEngine.Material DefaultMaterial { get; internal set; }
 
         internal IAssetCache AssetCache { get; set; }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -336,7 +336,7 @@ namespace MixedRealityExtension.App
 
         internal void OnReceive(Message message)
         {
-            if (message.Payload is LoadAssets || message.Payload is AssetUpdate)
+            if (message.Payload is LoadAssets || message.Payload is CreateAsset || message.Payload is AssetUpdate)
             {
                 var ncp = message.Payload as NetworkCommandPayload;
                 ncp.MessageId = message.Id;

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -51,7 +51,17 @@ namespace MixedRealityExtension.Assets
         /// <inheritdoc cref="GetAssetIdsInSource"/>
         public IEnumerable<Guid> GetAssetIdsInSource(AssetSource source = null)
         {
-            assetsBySource.TryGetValue(source, out var guids);
+            List<Guid> guids;
+
+            if (source != null)
+            {
+                assetsBySource.TryGetValue(source, out guids);
+            }
+            else
+            {
+                guids = manualAssets;
+            }
+
             return guids;
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetSource.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetSource.cs
@@ -43,9 +43,10 @@ namespace MixedRealityExtension.Assets
 
         public override bool Equals(object other)
         {
-            return other is AssetSource otherSource &&
+            return other != null &&
+                other is AssetSource otherSource &&
                 this.ContainerType == otherSource.ContainerType &&
-                this.Uri.Equals(otherSource.Uri);
+                this.Uri == otherSource.Uri;
         }
 
         public override int GetHashCode()
@@ -53,16 +54,6 @@ namespace MixedRealityExtension.Assets
             return 313
                 ^ 317 * ContainerType.GetHashCode()
                 ^ 317 * Uri.GetHashCode();
-        }
-
-        public static bool operator ==(AssetSource a, AssetSource b)
-        {
-            return a.Equals(b);
-        }
-
-        public static bool operator !=(AssetSource a, AssetSource b)
-        {
-            return !a.Equals(b);
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
@@ -103,6 +103,11 @@ namespace MixedRealityExtension.Assets
     public struct Texture
     {
         /// <summary>
+        /// The URI of the source data for this texture
+        /// </summary>
+        public string Uri;
+
+        /// <summary>
         /// The resolution of the texture
         /// </summary>
         public Vector2Patch Resolution;

--- a/MREUnityRuntime/MREUnityRuntimeLib/Factories/MWPrimitiveFactory.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Factories/MWPrimitiveFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using UnityEngine;
+using MixedRealityExtension.API;
 using MixedRealityExtension.Core.Types;
 using MixedRealityExtension.ProceduralToolkit;
 using MixedRealityExtension.Util.Unity;
@@ -13,17 +14,6 @@ namespace MixedRealityExtension.Factories
 {
     public class MWPrimitiveFactory : IPrimitiveFactory
     {
-        private readonly Material primitiveMaterial;
-
-        /// <summary>
-        /// Create a primitive factory that uses the built-in primitive generator
-        /// </summary>
-        /// <param name="defaultMaterial">The material to apply to new primitives</param>
-        public MWPrimitiveFactory(Material defaultMaterial)
-        {
-            primitiveMaterial = defaultMaterial;
-        }
-
         /// <inheritdoc />
         public GameObject CreatePrimitive(PrimitiveDefinition definition, GameObject parent, bool addCollider)
         {
@@ -112,7 +102,7 @@ namespace MixedRealityExtension.Factories
 
             spawnedPrimitive.AddComponent<MeshFilter>().mesh = meshDraft.ToMesh();
             var renderer = spawnedPrimitive.AddComponent<MeshRenderer>();
-            renderer.sharedMaterial = primitiveMaterial;
+            renderer.sharedMaterial = MREAPI.AppsAPI.DefaultMaterial;
 
             if (addCollider)
             {

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Util\Unity\MWGOTreeWalker.cs" />
     <Compile Include="Util\Unity\MWUnityHelpers.cs" />
     <Compile Include="Util\Unity\MWUnityTypeExtensions.cs" />
+    <Compile Include="Util\Unity\TextureFetcher.cs" />
     <Compile Include="Util\UtilMethods.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/AssetCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/AssetCommandPayloads.cs
@@ -64,4 +64,16 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// </summary>
         public Guid PrefabId;
     }
+
+    /// <summary>
+    /// App => Engine
+    /// Generate a new native asset with the included properties
+    /// </summary>
+    public class CreateAsset : NetworkCommandPayload
+    {
+        /// <summary>
+        /// Initial properties of the newly created asset
+        /// </summary>
+        public Asset Definition;
+    }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
@@ -60,6 +60,7 @@ namespace MixedRealityExtension.Messaging.Payloads
     [PayloadType(typeof(AssetsLoaded), "assets-loaded")]
     [PayloadType(typeof(LookAt), "look-at")]
     [PayloadType(typeof(AssetUpdate), "asset-update")]
+    [PayloadType(typeof(CreateAsset), "create-asset")]
     internal static class PayloadTypeRegistry
     {
         private static Dictionary<string, Type> _stringToPayloadMap;

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
@@ -23,7 +23,7 @@ namespace MixedRealityExtension.PluginInterfaces
         /// </summary>
         /// <param name="source">The asset source</param>
         /// <returns>A list of IDs, or null if the given source is not loaded.</returns>
-        IEnumerable<Guid> GetAssetIdsInSource(AssetSource source);
+        IEnumerable<Guid> GetAssetIdsInSource(AssetSource source = null);
 
         /// <summary>
         /// Retrieve an asset from the cache by ID, or null if an asset with that ID is not loaded.
@@ -42,10 +42,9 @@ namespace MixedRealityExtension.PluginInterfaces
         /// <summary>
         /// Cache an asset with the given lookup values.
         /// </summary>
-        /// <param name="source">The origin container.</param>
-        /// <param name="id">The ID of the asset.</param>
         /// <param name="asset">The native Unity asset</param>
-        void CacheAsset(AssetSource source, Guid id, UnityEngine.Object asset);
-
+        /// <param name="id">The ID of the asset.</param>
+        /// <param name="source">The origin container.</param>
+        void CacheAsset(UnityEngine.Object asset, Guid id, AssetSource source = null);
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/TextureFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/TextureFetcher.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MixedRealityExtension.Util.Unity
+{
+    public static class TextureFetcher
+    {
+        public struct FetchResult
+        {
+            public Texture Texture;
+            public string FailureMessage;
+            public bool IsPopulated => Texture != null || FailureMessage != null;
+        }
+
+        public static async Task<FetchResult> LoadTextureTask(MonoBehaviour runner, Uri uri)
+        {
+            FetchResult result = new FetchResult() {
+                Texture = null,
+                FailureMessage = null
+            };
+
+            runner.StartCoroutine(LoadTextureCoroutine());
+            while (!result.IsPopulated)
+            {
+                await Task.Delay(50);
+            }
+
+            return result;
+
+            IEnumerator LoadTextureCoroutine()
+            {
+                using (var www = UnityEngine.Networking.UnityWebRequestTexture.GetTexture(uri, true))
+                {
+                    yield return www.SendWebRequest();
+                    if (www.isNetworkError)
+                    {
+                        result.FailureMessage = www.error;
+                    }
+                    else if (www.isHttpError)
+                    {
+                        result.FailureMessage = $"[{www.responseCode}] {uri}";
+                    }
+                    else
+                    {
+                        result.Texture = UnityEngine.Networking.DownloadHandlerTexture.GetContent(www);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/UtilMethods.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/UtilMethods.cs
@@ -120,5 +120,24 @@ namespace MixedRealityExtension.Util
                 l.Contains("Rethrow")));
             return $"{message} The trace is below:\n{error}\n{trace}";
         }
+
+        /// <summary>
+        /// A useful utility to transprently insert default values into a dictionary
+        /// </summary>
+        /// <typeparam name="K">The dictionary key type</typeparam>
+        /// <typeparam name="V">The dictionary value type</typeparam>
+        /// <param name="_this">The dictionary</param>
+        /// <param name="key">The key whose value you want to get or create</param>
+        /// <param name="creator">A function that returns a default value for insertion</param>
+        /// <returns></returns>
+        internal static V GetOrCreate<K,V>(this Dictionary<K,V> _this, K key, Func<V> creator)
+        {
+            if (!_this.ContainsKey(key))
+            {
+                _this[key] = creator();
+            }
+
+            return _this[key];
+        }
     }
 }


### PR DESCRIPTION
* Add support for a new `create-asset` message, which generates a single standalone asset
* Add a public default material initialization parameter, which is used for primitives, and should be used for glTFs in Altspace.
* Added a string Uri field to Texture objects
* Added a handy `dictionary.GetOrCreate(key, defaultConstructor)` utility function