### PR TITLE
Support material alpha blending and cutout

### DIFF
--- a/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
@@ -851,8 +851,9 @@ MonoBehaviour:
     type: 2}
   MREURL: ws://localhost:3901
   testNames:
-  - asset-early-assignment-test
+  - asset-early-assignment
   - asset-preload-test
+  - mutable-asset-test
   - clock-sync-test
   - gltf-animation-test
   - gltf-concurrency-test
@@ -861,7 +862,6 @@ MonoBehaviour:
   - interpolation-test
   - library-test
   - look-at-test
-  - mutable-asset-test
   - primitives-test
   - reparent-test
   - rigid-body-test

--- a/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
@@ -851,9 +851,9 @@ MonoBehaviour:
     type: 2}
   MREURL: ws://localhost:3901
   testNames:
-  - asset-early-assignment
+  - asset-early-assignment-test
+  - asset-mutability-test
   - asset-preload-test
-  - mutable-asset-test
   - clock-sync-test
   - gltf-animation-test
   - gltf-concurrency-test

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -29,6 +29,7 @@ namespace MixedRealityExtension.API
         /// <param name="libraryFactory">The library resource factory to use within the runtime.</param>
         /// <param name="assetCache">The place for this MRE to cache its meshes, etc.</param>
         /// <param name="gltfImporterFactory">The glTF loader factory. Uses default GLTFSceneImporter if omitted.</param>
+        /// <param name="materialPatcher">Overrides default material property map (color and mainTexture only).</param>
         /// <param name="logger">The logger to be used by the MRE SDK.</param>
         public static void InitializeAPI(
             UnityEngine.Material defaultMaterial,
@@ -38,6 +39,7 @@ namespace MixedRealityExtension.API
             ILibraryResourceFactory libraryFactory = null,
             IAssetCache assetCache = null,
             IGLTFImporterFactory gltfImporterFactory = null,
+            IMaterialPatcher materialPatcher = null,
             IMRELogger logger = null)
         {
             AppsAPI.DefaultMaterial = defaultMaterial;
@@ -47,6 +49,7 @@ namespace MixedRealityExtension.API
             AppsAPI.LibraryResourceFactory = libraryFactory;
             AppsAPI.AssetCache = assetCache ?? new AssetCache();
             AppsAPI.GLTFImporterFactory = gltfImporterFactory ?? new GLTFImporterFactory();
+            AppsAPI.MaterialPatcher = materialPatcher ?? new DefaultMaterialPatcher();
 
 #if ANDROID_DEBUG
             Logger = logger ?? new UnityLogger();
@@ -81,7 +84,10 @@ namespace MixedRealityExtension.API
         /// </summary>
         public UnityEngine.Material DefaultMaterial { get; internal set; }
 
-        internal IAssetCache AssetCache { get; set; }
+        /// <summary>
+        /// The pool of assets available to MREs
+        /// </summary>
+        public IAssetCache AssetCache { get; internal set; }
 
         internal IBehaviorFactory BehaviorFactory { get; set; }
 
@@ -92,6 +98,8 @@ namespace MixedRealityExtension.API
         internal ILibraryResourceFactory LibraryResourceFactory { get; set; }
 
         internal IGLTFImporterFactory GLTFImporterFactory { get; set; }
+
+        internal IMaterialPatcher MaterialPatcher { get; set; }
 
         /// <summary>
         /// Creates a new mixed reality extension app and adds it to the MRE runtime.

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
@@ -72,6 +72,27 @@ namespace MixedRealityExtension.Assets
     }
 
     /// <summary>
+    /// How a material's alpha channel should be used
+    /// </summary>
+    public enum AlphaMode
+    {
+        /// <summary>
+        /// Draw opaque regardless of alpha
+        /// </summary>
+        Opaque = 0,
+
+        /// <summary>
+        /// Draw opaque, unless alpha drops below the specified cutoff
+        /// </summary>
+        TransparentCutout,
+
+        /// <summary>
+        /// Blend with the background by the factor of alpha
+        /// </summary>
+        Transparent
+    }
+
+    /// <summary>
     /// Contains material asset info
     /// </summary>
     public struct Material
@@ -95,6 +116,16 @@ namespace MixedRealityExtension.Assets
         /// Scale the texture by this amount in each axis
         /// </summary>
         public Vector2Patch MainTextureScale;
+
+        /// <summary>
+        /// How this material should treat the color/texture alpha channel
+        /// </summary>
+        public AlphaMode? AlphaMode;
+
+        /// <summary>
+        /// If AlphaMode is TransparentCutout, this is the transparency threshold
+        /// </summary>
+        public float? AlphaCutoff;
     }
 
     /// <summary>

--- a/MREUnityRuntime/MREUnityRuntimeLib/Factories/DefaultMaterialApplicator.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Factories/DefaultMaterialApplicator.cs
@@ -1,0 +1,47 @@
+﻿using MixedRealityExtension.API;
+using MixedRealityExtension.Patching;
+using MixedRealityExtension.Patching.Types;
+using MixedRealityExtension.PluginInterfaces;
+using MixedRealityExtension.Util.Unity;
+using System;
+using Material = UnityEngine.Material;
+using MWMaterial = MixedRealityExtension.Assets.Material;
+using Texture = UnityEngine.Texture;
+
+namespace MixedRealityExtension.Factories
+{
+    /// <summary>
+    /// Default implementation of IMaterialPatcher. Only handles color and mainTexture property updates.
+    /// </summary>
+    public class DefaultMaterialPatcher : IMaterialPatcher
+    {
+        /// <inheritdoc />
+        public void ApplyMaterialPatch(Material material, MWMaterial patch)
+        {
+            if (patch.Color != null)
+                material.color = material.color.ToMWColor().ApplyPatch(patch.Color).ToColor();
+
+            if (patch.MainTextureId == Guid.Empty)
+                material.mainTexture = null;
+            else if (patch.MainTextureId != null)
+                material.mainTexture = (Texture)MREAPI.AppsAPI.AssetCache.GetAsset(patch.MainTextureId.Value);
+
+            if (patch.MainTextureOffset != null)
+                material.mainTextureOffset = material.mainTextureOffset.ToMWVector2().ApplyPatch(patch.MainTextureOffset).ToVector2();
+            if (patch.MainTextureScale != null)
+                material.mainTextureScale = material.mainTextureScale.ToMWVector2().ApplyPatch(patch.MainTextureScale).ToVector2();
+        }
+
+        /// <inheritdoc />
+        public MWMaterial GeneratePatch(Material material)
+        {
+            return new MWMaterial()
+            {
+                Color = new ColorPatch(material.color),
+                MainTextureId = MREAPI.AppsAPI.AssetCache.GetId(material.mainTexture),
+                MainTextureOffset = new Vector2Patch(material.mainTextureOffset),
+                MainTextureScale = new Vector2Patch(material.mainTextureScale)
+            };
+        }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Core\Interfaces\IUserInfo.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />
+    <Compile Include="Factories\DefaultMaterialApplicator.cs" />
     <Compile Include="Messaging\Payloads\AssetCommandPayloads.cs" />
     <Compile Include="Patching\Types\Vector2Patch.cs" />
     <Compile Include="PluginInterfaces\IAssetCache.cs" />
@@ -103,6 +104,7 @@
     <Compile Include="Messaging\Protocols\Idle.cs" />
     <Compile Include="PluginInterfaces\IGltfImporterFactory.cs" />
     <Compile Include="PluginInterfaces\ILibraryResourceFactory.cs" />
+    <Compile Include="PluginInterfaces\IMaterialPatcher.cs" />
     <Compile Include="PluginInterfaces\IMRELogger.cs" />
     <Compile Include="PluginInterfaces\ITextFactory.cs" />
     <Compile Include="Behaviors\Actions\Action.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IMaterialPatcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IMaterialPatcher.cs
@@ -1,0 +1,25 @@
+﻿using Material = UnityEngine.Material;
+using MWMaterial = MixedRealityExtension.Assets.Material;
+
+namespace MixedRealityExtension.PluginInterfaces
+{
+    /// <summary>
+    /// Responsible for translating between the host's material properties and the API properties
+    /// </summary>
+    public interface IMaterialPatcher
+    {
+        /// <summary>
+        /// Apply the patch from the app to the material
+        /// </summary>
+        /// <param name="material">An instance of the default MRE material provided on load</param>
+        /// <param name="patch">The update from the app. Unmodified properties will be null.</param>
+        void ApplyMaterialPatch(Material material, MWMaterial patch);
+
+        /// <summary>
+        /// Generate an API patch from the Unity material's current state
+        /// </summary>
+        /// <param name="material">An instance of the default MRE material provided on load</param>
+        /// <returns>A full definition of the given material</returns>
+        MWMaterial GeneratePatch(Material material);
+    }
+}


### PR DESCRIPTION
* Adds `AlphaMode` and `AlphaCutoff` fields to the material patch
* Abstracts Unity material reads and writes to an `IMaterialPatcher` plugin instance. This is necessary because Unity's API does not provide a shader-agnostic transparency mode accessor.