### PR TITLE
[Unity] Fixes for stability

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/DashFormattedEnumConverter.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/DashFormattedEnumConverter.cs
@@ -1,23 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using MixedRealityExtension.Util;
 using Newtonsoft.Json;
 
 namespace MixedRealityExtension.Messaging.Payloads.Converters
 {
     /// <summary>
-    /// Json converter for the OperatingModel enum.
+    /// Json converter for dash-formatted enumerations.
     /// </summary>
     public class DashFormattedEnumConverter : JsonConverter
     {
         /// <inheritdoc />
         public override bool CanConvert(Type objectType)
         {
-            return objectType.IsEnum;
+            return UtilMethods.GetActualType(objectType).IsEnum;
         }
 
         /// <inheritdoc />
@@ -25,13 +23,13 @@ namespace MixedRealityExtension.Messaging.Payloads.Converters
         {
             var value = (string)reader.Value;
             value = value.Replace("-", "");
-            return Enum.Parse(objectType, value, true);
+            return Enum.Parse(UtilMethods.GetActualType(objectType), value, true);
         }
 
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var name = Enum.GetName(value.GetType(), value);
+            var name = Enum.GetName(UtilMethods.GetActualType(value.GetType()), value);
 
             var sb = new StringBuilder();
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/PatchingUtils.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/PatchingUtils.cs
@@ -40,6 +40,26 @@ namespace MixedRealityExtension.Patching
             }
         }
 
+        public static string GeneratePatch(string _old, string _new)
+        {
+            if (_old == null && _new != null)
+            {
+                return _new;
+            }
+            else if (_new == null)
+            {
+                return null;
+            }
+            if (_old != _new)
+            {
+                return _new;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public static Vector3Patch GeneratePatch(MWVector3 _old, Vector3 _new)
         {
             if (_old == null && _new != null)
@@ -51,12 +71,21 @@ namespace MixedRealityExtension.Patching
                 return null;
             }
 
-            return new Vector3Patch()
+            var patch = new Vector3Patch()
             {
                 X = _old.X != _new.x ? (float?)_new.x : null,
                 Y = _old.Y != _new.y ? (float?)_new.y : null,
                 Z = _old.Z != _new.z ? (float?)_new.z : null
             };
+
+            if (patch.IsPatched())
+            {
+                return patch;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public static QuaternionPatch GeneratePatch(MWQuaternion _old, Quaternion _new)
@@ -70,13 +99,22 @@ namespace MixedRealityExtension.Patching
                 return null;
             }
 
-            return new QuaternionPatch()
+            var patch = new QuaternionPatch()
             {
                 X = _old.X != _new.x ? (float?)_new.x : null,
                 Y = _old.Y != _new.y ? (float?)_new.y : null,
                 Z = _old.Z != _new.z ? (float?)_new.z : null,
                 W = _old.W != _new.w ? (float?)_new.w : null
             };
+
+            if (patch.IsPatched())
+            {
+                return patch;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public static TransformPatch GeneratePatch(MWTransform _old, Transform _new)
@@ -115,13 +153,22 @@ namespace MixedRealityExtension.Patching
                 return null;
             }
 
-            return new ColorPatch()
+            var patch = new ColorPatch()
             {
                 R = _old.R != _new.r ? (float?)_new.r : null,
                 G = _old.G != _new.g ? (float?)_new.g : null,
                 B = _old.B != _new.b ? (float?)_new.b : null,
                 A = _old.A != _new.a ? (float?)_new.a : null
             };
+
+            if (patch.IsPatched())
+            {
+                return patch;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public static RigidBodyPatch GeneratePatch(RigidBody _old, Rigidbody _new, Transform sceneRoot)
@@ -135,8 +182,9 @@ namespace MixedRealityExtension.Patching
                 return null;
             }
 
-            return new RigidBodyPatch()
+            var patch = new RigidBodyPatch()
             {
+                // Do not include Position or Rotation in the patch.
                 Velocity = GeneratePatch(_old.Velocity, sceneRoot.InverseTransformDirection(_new.velocity)),
                 AngularVelocity = GeneratePatch(_old.AngularVelocity, sceneRoot.InverseTransformDirection(_new.angularVelocity)),
                 CollisionDetectionMode = GeneratePatch(
@@ -149,6 +197,15 @@ namespace MixedRealityExtension.Patching
                 Mass = GeneratePatch(_old.Mass, _new.mass),
                 UseGravity = GeneratePatch(_old.UseGravity, _new.useGravity),
             };
+
+            if (patch.IsPatched())
+            {
+                return patch;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public static LightPatch GeneratePatch(MRELight _old, UnityLight _new)
@@ -162,7 +219,7 @@ namespace MixedRealityExtension.Patching
                 return null;
             }
 
-            return new LightPatch()
+            var patch = new LightPatch()
             {
                 Enabled = _new.enabled,
                 Type = UtilMethods.ConvertEnum<Core.Interfaces.LightType, UnityEngine.LightType>(_new.type),
@@ -171,6 +228,15 @@ namespace MixedRealityExtension.Patching
                 Intensity = _new.intensity,
                 SpotAngle = _new.spotAngle
             };
+
+            if (patch.IsPatched())
+            {
+                return patch;
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
@@ -16,6 +16,14 @@ namespace MixedRealityExtension.Patching.Types
         private MRERigidBodyConstraints? _constraintFlags;
         private MRERigidBodyConstraints[] _constraints;
 
+        // Local only. Not synchronized.
+        [PatchProperty]
+        public Vector3Patch Position { get; set; }
+
+        // Local only. Not synchronized.
+        [PatchProperty]
+        public QuaternionPatch Rotation { get; set; }
+
         [PatchProperty]
         public Vector3Patch Velocity { get; set; }
 
@@ -99,6 +107,7 @@ namespace MixedRealityExtension.Patching.Types
 
         internal RigidBodyPatch(Rigidbody rigidbody, Transform sceneRoot)
         {
+            // Do not include Position or Rotation in the patch.
             Velocity = new Vector3Patch(sceneRoot.InverseTransformDirection(rigidbody.velocity));
             AngularVelocity = new Vector3Patch(sceneRoot.InverseTransformDirection(rigidbody.angularVelocity));
             Mass = rigidbody.mass;

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/UtilMethods.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/UtilMethods.cs
@@ -74,6 +74,26 @@ namespace MixedRealityExtension.Util
         }
 
         /// <summary>
+        /// Returns true if the value is a Nullable type.
+        /// </summary>
+        internal static bool IsNullableType(Type type)
+        {
+            return (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
+        /// <summary>
+        /// If the given type is Nullable, return the underlying type. Otherwise return the original type.
+        /// </summary>
+        internal static Type GetActualType(Type objectType)
+        {
+            if (IsNullableType(objectType))
+            {
+                return Nullable.GetUnderlyingType(objectType);
+            }
+            return objectType;
+        }
+
+        /// <summary>
         /// Generates a GUID from the provided string. Note the result is not a valid GUID (not compliant with RFC 4122), only shaped like a GUID (a reasonably unique 16-byte value).
         /// </summary>
         /// <param name="str"></param>


### PR DESCRIPTION
Found and fixed numerous issues exposed by stressing network traffic in different ways.
- Fix patching of rigid body position and rotation (happens via transform sync, but applied to the rigid body directly).
- Rigid body patch was applying new values when none were present in the patch.  Added protection for this.
- Updated DashFormattedEnumConverter to work with Nullable enum types.
- Updated GeneratePatch functions to return null if there was no patch, enabling better actor-update deltas by not sending empty objects.
- In the case of a failure to process a network message, send a reply message indicating the failure. This will unblock any promises on the app side, and also communicate some detail about the failure.

Also:
- General cleanup of actor patching code.