### PR TITLE
[Unity] Send an actor update when animation stops

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -296,6 +296,26 @@ namespace MixedRealityExtension.Core
             }
         }
 
+        internal void SendActorUpdate(SubscriptionType flags)
+        {
+            ActorPatch actorPatch = new ActorPatch(Id);
+
+            if ((flags & SubscriptionType.Transform) != SubscriptionType.None)
+            {
+                actorPatch.Transform = transform.ToMWTransform().AsPatch();
+            }
+
+            //if ((flags & SubscriptionType.Rigidbody) != SubscriptionType.None)
+            //{
+            //    actorPatch.Transform = this.RigidBody.AsPatch();
+            //}
+
+            if (actorPatch.IsPatched())
+            {
+                App.EventManager.QueueEvent(new ActorChangedEvent(Id, actorPatch));
+            }
+        }
+
         #endregion
 
         #region MonoBehaviour Virtual Methods

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 using MixedRealityExtension.Animation;
 using MixedRealityExtension.Messaging.Events.Types;
+using MixedRealityExtension.Messaging.Payloads;
 using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.Util;
 using MixedRealityExtension.Util.Unity;
@@ -483,6 +484,13 @@ namespace MixedRealityExtension.Core.Components
                         {
                             animation[animationName].enabled = enabled.Value;
                             // NOTE: animationData.Enabled will be set in the next call to Update()
+
+                            // When stopping an animation, send an update to the app letting it know the final animation state.
+                            if (!enabled.Value && (AttachedActor.App.IsAuthoritativePeer || AttachedActor.App.OperatingModel == OperatingModel.ServerAuthoritative))
+                            {
+                                // FUTURE: Add additional animatable properties as support for them is added (light color, etc).
+                                AttachedActor.SendActorUpdate(SubscriptionType.Transform);
+                            }
                         }
                         animation[animationName].weight = enabled.Value ? 1.0f : 0.0f;
                     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Types/MWTransform.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Types/MWTransform.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using MixedRealityExtension.Patching.Types;
 using System;
 
 namespace MixedRealityExtension.Core.Types
@@ -69,6 +70,16 @@ namespace MixedRealityExtension.Core.Types
                 Position.Equals(other.Position) &&
                 Rotation.Equals(other.Rotation) &&
                 Scale.Equals(other.Scale);
+        }
+
+        internal TransformPatch AsPatch()
+        {
+            return new TransformPatch()
+            {
+                Position = new Vector3Patch(Position),
+                Rotation = new QuaternionPatch(Rotation),
+                Scale = new Vector3Patch(Scale)
+            };
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug where new clients joining an app wouldn't get the correct transforms of actors that had animated then stopped animating prior to them joining.