### PR TITLE
[Unity] Remove unused code

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -588,16 +588,6 @@ namespace MixedRealityExtension.App
             }
         }
 
-        private void UpdateUserSubsciptions(UpdateSubscriptions payload)
-        {
-            var user = _userManager.FindUser(payload.Id);
-            if (user != null)
-            {
-                user.RemoveSubscriptions(this.InstanceId, payload.Removes);
-                user.AddSubscriptions(this.InstanceId, payload.Adds);
-            }
-        }
-
         #endregion
 
         #region Command Handlers
@@ -817,18 +807,7 @@ namespace MixedRealityExtension.App
         [CommandHandler(typeof(UpdateSubscriptions))]
         private void OnUpdateSubscriptions(UpdateSubscriptions payload)
         {
-            switch (payload.OwnerType)
-            {
-                case SubscriptionOwnerType.Actor:
-                    UpdateActorSubsciptions(payload);
-                    break;
-                case SubscriptionOwnerType.User:
-                    UpdateUserSubsciptions(payload);
-                    break;
-                default:
-                    MREAPI.Logger.LogError($"Invalid subscription owner type: {payload.OwnerType}");
-                    break;
-            }
+            UpdateActorSubsciptions(payload);
         }
 
         [CommandHandler(typeof(RigidBodyCommands))]

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
@@ -232,11 +232,6 @@ namespace MixedRealityExtension.Messaging.Payloads
         public Guid Id { get; set; }
 
         /// <summary>
-        /// The subscription owner type. See <see cref="SubscriptionOwnerType"/>.
-        /// </summary>
-        public SubscriptionOwnerType OwnerType { get; set; }
-
-        /// <summary>
         /// The subscription types to add to the object. See <see cref="SubscriptionType"/>.
         /// </summary>
         public IEnumerable<SubscriptionType> Adds { get; set; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Payloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Payloads.cs
@@ -59,22 +59,6 @@ namespace MixedRealityExtension.Messaging.Payloads
     }
 
     /// <summary>
-    /// The type of subscription owner.
-    /// </summary>
-    public enum SubscriptionOwnerType
-    {
-        /// <summary>
-        /// An actor subscription owner.
-        /// </summary>
-        Actor,
-
-        /// <summary>
-        /// A user subscription owner.
-        /// </summary>
-        User
-    }
-
-    /// <summary>
     /// The kind of connection we've made with the app. This setting provides a hint to the client about how and when it should send updates to the app.
     /// </summary>
     public enum OperatingModel

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
@@ -6,24 +6,31 @@ using System;
 
 namespace MixedRealityExtension.Patching.Types
 {
-    public class UserPatch : MixedRealityExtensionObjectPatch
+    public class UserPatch : IPatchable
     {
+        public Guid Id { get; set; }
+
+        [PatchProperty]
+        public string Name { get; set; }
+
         public UserPatch()
         {
-
         }
 
         internal UserPatch(Guid id)
-            : base(id)
         {
-
+            Id = id;
         }
 
         internal UserPatch(User user)
-            : base(user.Id)
+            : this(user.Id)
         {
             Name = user.Name;
-            Transform = PatchingUtilMethods.GeneratePatch((MWTransform)null, user.transform);
+        }
+
+        public bool IsPatched()
+        {
+            return false;
         }
     }
 }


### PR DESCRIPTION
Removed the notion of user subscriptions and user transform. We weren't using them, and probably never will.