### PR TITLE
[Unity] Use DashFormattedEnumConverter for all enums (JSON serialization)

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using MixedRealityExtension.Messaging.Payloads;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace MixedRealityExtension
 {
@@ -19,7 +18,7 @@ namespace MixedRealityExtension
                 NullValueHandling = NullValueHandling.Ignore,
             };
 
-            SerializerSettings.Converters.Add(new StringEnumConverter() { CamelCaseText = true });
+            SerializerSettings.Converters.Add(new Messaging.Payloads.Converters.DashFormattedEnumConverter());
             SerializerSettings.Converters.Add(new PayloadConverter());
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using MixedRealityExtension.Core.Types;
 using Newtonsoft.Json.Linq;
 using MixedRealityExtension.Controllers;
-using Newtonsoft.Json;
 
 namespace MixedRealityExtension.Messaging.Payloads
 {
@@ -370,7 +369,6 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// <summary>
         /// The wrap mode of the animation. See <see cref="MWAnimationWrapMode"/>.
         /// </summary>
-        [JsonConverter(typeof(Converters.DashFormattedEnumConverter))]
         public MWAnimationWrapMode WrapMode { get; set; }
 
         /// <summary>

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Payloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Payloads.cs
@@ -3,10 +3,8 @@
 using MixedRealityExtension.Behaviors;
 using MixedRealityExtension.Behaviors.Actions;
 using MixedRealityExtension.Patching.Types;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using MixedRealityExtension.Core.Types;
 
 namespace MixedRealityExtension.Messaging.Payloads
 {
@@ -117,7 +115,6 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// <summary>
         /// The kind of connection this is. <see cref="OperatingModel"/>
         /// </summary>
-        [JsonConverter(typeof(Converters.DashFormattedEnumConverter))]
         public OperatingModel OperatingModel;
     }
 


### PR DESCRIPTION
Added DashFormattedEnumConverter to serializer settings so that it will be used for all enums.