### PR TITLE
Set collider API integration support for Unity

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -30,6 +30,7 @@ namespace MixedRealityExtension.API
         /// <param name="assetCache">The place for this MRE to cache its meshes, etc.</param>
         /// <param name="gltfImporterFactory">The glTF loader factory. Uses default GLTFSceneImporter if omitted.</param>
         /// <param name="materialPatcher">Overrides default material property map (color and mainTexture only).</param>
+		/// <param name="engineConstants">Engine constants supplied by the host app.</param>
         /// <param name="logger">The logger to be used by the MRE SDK.</param>
         public static void InitializeAPI(
             UnityEngine.Material defaultMaterial,
@@ -41,6 +42,7 @@ namespace MixedRealityExtension.API
             IGLTFImporterFactory gltfImporterFactory = null,
             IMaterialPatcher materialPatcher = null,
             IUserInfoProvider userInfoProvider = null,
+			IEngineConstants engineConstants = null,
             IMRELogger logger = null)
         {
             AppsAPI.DefaultMaterial = defaultMaterial;
@@ -52,6 +54,7 @@ namespace MixedRealityExtension.API
             AppsAPI.GLTFImporterFactory = gltfImporterFactory ?? new GLTFImporterFactory();
             AppsAPI.MaterialPatcher = materialPatcher ?? new DefaultMaterialPatcher();
             AppsAPI.UserInfoProvider = userInfoProvider ?? new NullUserInfoProvider();
+			AppsAPI.EngineConstants = engineConstants;
 
 #if ANDROID_DEBUG
             Logger = logger ?? new UnityLogger();
@@ -102,6 +105,8 @@ namespace MixedRealityExtension.API
         internal IGLTFImporterFactory GLTFImporterFactory { get; set; }
 
         internal IMaterialPatcher MaterialPatcher { get; set; }
+		
+		internal IEngineConstants EngineConstants { get; set; }
 
         /// <summary>
         /// Provider of app/session scoped IUserInfo interfaces.

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -30,7 +30,7 @@ namespace MixedRealityExtension.API
         /// <param name="assetCache">The place for this MRE to cache its meshes, etc.</param>
         /// <param name="gltfImporterFactory">The glTF loader factory. Uses default GLTFSceneImporter if omitted.</param>
         /// <param name="materialPatcher">Overrides default material property map (color and mainTexture only).</param>
-		/// <param name="engineConstants">Engine constants supplied by the host app.</param>
+        /// <param name="engineConstants">Engine constants supplied by the host app.</param>
         /// <param name="logger">The logger to be used by the MRE SDK.</param>
         public static void InitializeAPI(
             UnityEngine.Material defaultMaterial,
@@ -54,7 +54,7 @@ namespace MixedRealityExtension.API
             AppsAPI.GLTFImporterFactory = gltfImporterFactory ?? new GLTFImporterFactory();
             AppsAPI.MaterialPatcher = materialPatcher ?? new DefaultMaterialPatcher();
             AppsAPI.UserInfoProvider = userInfoProvider ?? new NullUserInfoProvider();
-			AppsAPI.EngineConstants = engineConstants;
+            AppsAPI.EngineConstants = engineConstants;
 
 #if ANDROID_DEBUG
             Logger = logger ?? new UnityLogger();
@@ -105,8 +105,8 @@ namespace MixedRealityExtension.API
         internal IGLTFImporterFactory GLTFImporterFactory { get; set; }
 
         internal IMaterialPatcher MaterialPatcher { get; set; }
-		
-		internal IEngineConstants EngineConstants { get; set; }
+
+        internal IEngineConstants EngineConstants { get; set; }
 
         /// <summary>
         /// Provider of app/session scoped IUserInfo interfaces.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -16,6 +16,7 @@ using MixedRealityExtension.Messaging.Events;
 using MixedRealityExtension.Messaging.Events.Types;
 using MixedRealityExtension.Messaging.Payloads;
 using MixedRealityExtension.Messaging.Protocols;
+using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.RPC;
 using MixedRealityExtension.Util;
@@ -455,7 +456,7 @@ namespace MixedRealityExtension.App
                 return new OperationResult()
                 {
                     ResultCode = OperationResultCode.Error,
-                    Message = string.Format("Could not find an actor with id {0} to enable a rigidbody on.", actorId)
+                    Message = $"Could not find an actor with id {actorId} to enable a rigidbody on."
                 };
             }
             else
@@ -472,7 +473,7 @@ namespace MixedRealityExtension.App
             {
                 return new OperationResult()
                 {
-                    Message = String.Format("PatchLight: Actor {0} not found", actorId),
+                    Message = $"PatchLight: Actor {actorId} not found",
                     ResultCode = OperationResultCode.Error
                 };
             }

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using MixedRealityExtension.Animation;
 using MixedRealityExtension.API;
 using MixedRealityExtension.Assets;
@@ -7,7 +8,6 @@ using MixedRealityExtension.Behaviors;
 using MixedRealityExtension.Core;
 using MixedRealityExtension.Core.Components;
 using MixedRealityExtension.Core.Interfaces;
-using MixedRealityExtension.Core.Types;
 using MixedRealityExtension.IPC;
 using MixedRealityExtension.IPC.Connections;
 using MixedRealityExtension.Messaging;
@@ -20,7 +20,6 @@ using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.RPC;
 using MixedRealityExtension.Util;
-using MixedRealityExtension.Util.Unity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -435,15 +434,15 @@ namespace MixedRealityExtension.App
                 };
 
                 Protocol.Send(new ObjectSpawned()
-                {
-                    Result = new OperationResult()
                     {
-                        ResultCode = resultCode,
-                        Message = trace.Message
+                        Result = new OperationResult()
+                        {
+                            ResultCode = resultCode,
+                            Message = trace.Message
+                        },
+                        Traces = new List<Trace>() { trace },
+                        Actors = actors?.Select((actor) => actor.GenerateInitialPatch()).ToList() ?? new List<ActorPatch>()
                     },
-                    Traces = new List<Trace>() { trace },
-                    Actors = actors?.Select((actor) => actor.GeneratePatch(ActorComponentType.All)).ToList() ?? new List<ActorPatch>()
-                },
                     payload.MessageId);
             }
         }
@@ -727,16 +726,16 @@ namespace MixedRealityExtension.App
             };
 
             Protocol.Send(new ObjectSpawned()
-            {
-                Result = new OperationResult()
                 {
-                    ResultCode = (actors != null) ? OperationResultCode.Success : OperationResultCode.Error,
-                    Message = trace.Message
-                },
+                    Result = new OperationResult()
+                    {
+                        ResultCode = (actors != null) ? OperationResultCode.Success : OperationResultCode.Error,
+                        Message = trace.Message
+                    },
 
-                Traces = new List<Trace>() { trace },
-                Actors = actors?.Select((actor) => actor.GeneratePatch(ActorComponentType.All)) ?? new ActorPatch[] { }
-            },
+                    Traces = new List<Trace>() { trace },
+                    Actors = actors?.Select((actor) => actor.GenerateInitialPatch()) ?? new ActorPatch[] { }
+                },
                 originalMessage.MessageId);
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Messaging.Payloads.Converters;
 using Newtonsoft.Json;
 
 namespace MixedRealityExtension
@@ -20,6 +21,7 @@ namespace MixedRealityExtension
 
             SerializerSettings.Converters.Add(new Messaging.Payloads.Converters.DashFormattedEnumConverter());
             SerializerSettings.Converters.Add(new PayloadConverter());
+            SerializerSettings.Converters.Add(new CollisionGeometryConverter());
         }
 
         /*

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -550,6 +550,7 @@ namespace MixedRealityExtension.Core
                     // We have a collider already of the same type as the desired new geometry.
                     // Update its values instead of removing and adding a new one.
                     colliderGeometry.Patch(_collider);
+                    return Collider;
                 }
                 else
                 {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using MixedRealityExtension.Core.Interfaces;
+using MixedRealityExtension.Patching;
+using MixedRealityExtension.Patching.Types;
+using MixedRealityExtension.Util.Unity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,8 +38,32 @@ namespace MixedRealityExtension.Core
         Mesh = 3
     }
 
-    public class Collider
+    public class Collider : ICollider
     {
+        private readonly UnityEngine.Collider _collider;
 
+        public bool IsEnabled => _collider.enabled;
+
+        public bool IsTrigger => _collider.isTrigger;
+
+        //public CollisionLayer CollisionLayer { get; set; }
+
+        public ColliderType ColliderType { get; private set; }
+
+        internal Collider(UnityEngine.Collider unityCollider)
+        {
+            _collider = unityCollider;
+        }
+
+        internal void ApplyPatch(ColliderPatch patch)
+        {
+            _collider.enabled = _collider.enabled.GetPatchApplied(IsEnabled.ApplyPatch(patch.IsEnabled));
+            _collider.isTrigger = _collider.isTrigger.GetPatchApplied(IsTrigger.ApplyPatch(patch.IsTrigger));
+        }
+
+        internal void SynchronizeEngine(ColliderPatch patch)
+        {
+            ApplyPatch(patch);
+        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using MixedRealityExtension.API;
 using MixedRealityExtension.Core.Interfaces;
 using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.Util.Unity;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UnityEngine;
+
+using UnityCollider = UnityEngine.Collider;
 
 namespace MixedRealityExtension.Core
 {
@@ -38,19 +38,23 @@ namespace MixedRealityExtension.Core
         Mesh = 3
     }
 
-    public class Collider : ICollider
+    internal class Collider : ICollider
     {
-        private readonly UnityEngine.Collider _collider;
+        private readonly UnityCollider _collider;
 
+        /// <inheritdoc />
         public bool IsEnabled => _collider.enabled;
 
+        /// <inheritdoc />
         public bool IsTrigger => _collider.isTrigger;
 
+        /// <inheritdoc />
         //public CollisionLayer CollisionLayer { get; set; }
 
+        /// <inheritdoc />
         public ColliderType ColliderType { get; private set; }
 
-        internal Collider(UnityEngine.Collider unityCollider)
+        internal Collider(UnityCollider unityCollider)
         {
             _collider = unityCollider;
         }
@@ -64,6 +68,44 @@ namespace MixedRealityExtension.Core
         internal void SynchronizeEngine(ColliderPatch patch)
         {
             ApplyPatch(patch);
+        }
+
+        internal ColliderPatch GenerateInitialPatch()
+        {
+            ColliderGeometry colliderGeo = null;
+
+            if (_collider is SphereCollider sphereCollider)
+            {
+                colliderGeo = new SphereColliderGeometry()
+                {
+                    Radius = sphereCollider.radius,
+                    Center = sphereCollider.center.ToMWVector3()
+                };
+            }
+            else if (_collider is BoxCollider boxCollider)
+            {
+                colliderGeo = new BoxColliderGeometry()
+                {
+                    Size = boxCollider.size.ToMWVector3(),
+                    Center = boxCollider.center.ToMWVector3()
+                };
+            }
+            else if (_collider is MeshCollider meshCollider)
+            {
+                colliderGeo = new MeshColliderGeometry();
+            }
+            else
+            {
+                MREAPI.Logger.LogWarning($"MRE SDK does not support the following Unity collider and will not " +
+                    $"be available in the MRE app.  Collider Type: {_collider.GetType()}");
+            }
+
+            return colliderGeo == null ? null : new ColliderPatch()
+                {
+                    IsEnabled = _collider.enabled,
+                    IsTrigger = _collider.isTrigger,
+                    ColliderGeometry = colliderGeo
+                };
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ColliderGeometry.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ColliderGeometry.cs
@@ -1,25 +1,46 @@
-﻿using MixedRealityExtension.Core.Types;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MixedRealityExtension.Core.Types;
 using MixedRealityExtension.Util.Unity;
 using UnityEngine;
 
+using UnityCollider = UnityEngine.Collider;
+
 namespace MixedRealityExtension.Core
 {
+    /// <summary>
+    /// Abstract class that represents the collider geometry.
+    /// </summary>
     public abstract class ColliderGeometry
     {
+        /// <summary>
+        /// The type of the collider.  <see cref="ColliderType"/>
+        /// </summary>
         public abstract ColliderType ColliderType { get; }
 
-        internal abstract void Patch(UnityEngine.Collider collider);
+        internal abstract void Patch(UnityCollider collider);
     }
 
+    /// <summary>
+    /// Class that represents the sphere geometry for a sphere collider.
+    /// </summary>
     public class SphereColliderGeometry : ColliderGeometry
     {
+        /// <inheritdoc />
         public override ColliderType ColliderType => ColliderType.Sphere;
 
+        /// <summary>
+        /// The radius of the sphere collider geometry.
+        /// </summary>
         public float? Radius { get; set; }
 
+        /// <summary>
+        /// The center of the sphere collider geometry.
+        /// </summary>
         public MWVector3 Center { get; set; }
 
-        internal override void Patch(UnityEngine.Collider collider)
+        internal override void Patch(UnityCollider collider)
         {
             if (collider is SphereCollider sphereCollider)
             {
@@ -41,15 +62,25 @@ namespace MixedRealityExtension.Core
         }
     }
 
+    /// <summary>
+    /// Class that represents the box geometry of a box collider.
+    /// </summary>
     public class BoxColliderGeometry : ColliderGeometry
     {
+        /// <inheritdoc />
         public override ColliderType ColliderType => ColliderType.Box;
 
+        /// <summary>
+        /// The size of the box collider geometry.
+        /// </summary>
         public MWVector3 Size { get; set; }
 
+        /// <summary>
+        /// The center of the box collider geometry.
+        /// </summary>
         public MWVector3 Center { get; set; }
 
-        internal override void Patch(UnityEngine.Collider collider)
+        internal override void Patch(UnityCollider collider)
         {
             if (collider is BoxCollider boxCollider)
             {
@@ -68,6 +99,20 @@ namespace MixedRealityExtension.Core
             {
                 collider.size = Size.ToVector3();
             }
+        }
+    }
+
+    /// <summary>
+    /// Class that represents the mesh geometry of a mesh collider.
+    /// </summary>
+    public class MeshColliderGeometry : ColliderGeometry
+    {
+        /// <inheritdoc />
+        public override ColliderType ColliderType => ColliderType.Mesh;
+
+        internal override void Patch(UnityCollider collider)
+        {
+            // We do not accept patching for mesh colliders from the app.
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ColliderGeometry.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ColliderGeometry.cs
@@ -1,0 +1,73 @@
+﻿using MixedRealityExtension.Core.Types;
+using MixedRealityExtension.Util.Unity;
+using UnityEngine;
+
+namespace MixedRealityExtension.Core
+{
+    public abstract class ColliderGeometry
+    {
+        public abstract ColliderType ColliderType { get; }
+
+        internal abstract void Patch(UnityEngine.Collider collider);
+    }
+
+    public class SphereColliderGeometry : ColliderGeometry
+    {
+        public override ColliderType ColliderType => ColliderType.Sphere;
+
+        public float? Radius { get; set; }
+
+        public MWVector3 Center { get; set; }
+
+        internal override void Patch(UnityEngine.Collider collider)
+        {
+            if (collider is SphereCollider sphereCollider)
+            {
+                Patch(sphereCollider);
+            }
+        }
+
+        private void Patch(SphereCollider collider)
+        {
+            if (Center != null)
+            {
+                collider.center = Center.ToVector3();
+            }
+
+            if (Radius != null)
+            {
+                collider.radius = Radius.Value;
+            }
+        }
+    }
+
+    public class BoxColliderGeometry : ColliderGeometry
+    {
+        public override ColliderType ColliderType => ColliderType.Box;
+
+        public MWVector3 Size { get; set; }
+
+        public MWVector3 Center { get; set; }
+
+        internal override void Patch(UnityEngine.Collider collider)
+        {
+            if (collider is BoxCollider boxCollider)
+            {
+                Patch(boxCollider);
+            }
+        }
+
+        private void Patch(BoxCollider collider)
+        {
+            if (Center != null)
+            {
+                collider.center = Center.ToVector3();
+            }
+
+            if (Size != null)
+            {
+                collider.size = Size.ToVector3();
+            }
+        }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using MixedRealityExtension.Animation;
 using MixedRealityExtension.Messaging.Events.Types;
 using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.Util;
 using MixedRealityExtension.Util.Unity;

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/ICollider.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/ICollider.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+namespace MixedRealityExtension.Core.Interfaces
+{
+    // public enum CollisionLayer
+    // {
+    //     Object,
+    //     Environment,
+    //     Hologram
+    // }
+
+    interface ICollider
+    {
+        bool IsEnabled { get; }
+
+        bool IsTrigger { get; }
+
+        //CollisionLayer CollisionLayer { get; }
+
+        ColliderType ColliderType { get; }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/ICollider.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Interfaces/ICollider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 namespace MixedRealityExtension.Core.Interfaces
 {
     // public enum CollisionLayer
@@ -9,14 +10,26 @@ namespace MixedRealityExtension.Core.Interfaces
     //     Hologram
     // }
 
-    interface ICollider
+    /// <summary>
+    /// The interface that represents a collider within the mixed reality extension runtime.
+    /// </summary>
+    public interface ICollider
     {
+        /// <summary>
+        /// Whether the collider is enabled.
+        /// </summary>
         bool IsEnabled { get; }
 
+        /// <summary>
+        /// Whether the collider is a trigger.
+        /// </summary>
         bool IsTrigger { get; }
 
         //CollisionLayer CollisionLayer { get; }
 
+        /// <summary>
+        /// The type of the collider.  <see cref="ColliderType"/>
+        /// </summary>
         ColliderType ColliderType { get; }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using MixedRealityExtension.App;
 using MixedRealityExtension.Core.Interfaces;
+using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
 using System;
 using System.Collections.Generic;

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -90,6 +90,8 @@
     <Compile Include="Assets\AssetSource.cs" />
     <Compile Include="Core\Attachment.cs" />
     <Compile Include="Core\Components\MREAttachmentComponent.cs" />
+    <Compile Include="Core\ColliderGeometry.cs" />
+    <Compile Include="Core\Interfaces\ICollider.cs" />
     <Compile Include="Core\Interfaces\IUserInfo.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />
@@ -97,7 +99,9 @@
     <Compile Include="PluginInterfaces\IUserInfoProvider.cs" />
     <Compile Include="Messaging\Payloads\AssetCommandPayloads.cs" />
     <Compile Include="Patching\Types\AttachmentPatch.cs" />
+    <Compile Include="Messaging\Payloads\Converters\CollisionGeometryConverter.cs" />
     <Compile Include="Patching\Types\Vector2Patch.cs" />
+    <Compile Include="Patching\Types\ColliderPatch.cs" />
     <Compile Include="PluginInterfaces\IAssetCache.cs" />
     <Compile Include="Assets\Definitions.cs" />
     <Compile Include="Assets\AssetLoader.cs" />
@@ -106,6 +110,7 @@
     <Compile Include="Core\Components\ActorComponentBase.cs" />
     <Compile Include="Factories\GLTFImporterFactory.cs" />
     <Compile Include="Messaging\Protocols\Idle.cs" />
+    <Compile Include="PluginInterfaces\IEngineConstants.cs" />
     <Compile Include="PluginInterfaces\IGltfImporterFactory.cs" />
     <Compile Include="PluginInterfaces\ILibraryResourceFactory.cs" />
     <Compile Include="PluginInterfaces\IMaterialPatcher.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/CollisionGeometryConverter.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/CollisionGeometryConverter.cs
@@ -1,4 +1,7 @@
-﻿using MixedRealityExtension.API;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MixedRealityExtension.API;
 using MixedRealityExtension.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -7,7 +10,7 @@ using System;
 namespace MixedRealityExtension.Messaging.Payloads.Converters
 {
     /// <summary>
-    /// Json converter for collision geometry serialized data.
+    /// Json converter for collision geometry serialization data.
     /// </summary>
     public class CollisionGeometryConverter : JsonConverter
     {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/CollisionGeometryConverter.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/CollisionGeometryConverter.cs
@@ -1,0 +1,59 @@
+﻿using MixedRealityExtension.API;
+using MixedRealityExtension.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace MixedRealityExtension.Messaging.Payloads.Converters
+{
+    /// <summary>
+    /// Json converter for collision geometry serialized data.
+    /// </summary>
+    public class CollisionGeometryConverter : JsonConverter
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ColliderGeometry);
+        }
+
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            try
+            {
+                JObject jObject = JObject.Load(reader);
+                var colliderType = jObject["colliderType"].ToObject<string>();
+
+                ColliderGeometry colliderGeometry = null;
+                switch (colliderType)
+                {
+                    case "sphere":
+                        colliderGeometry = new SphereColliderGeometry();
+                        break;
+                    case "box":
+                        colliderGeometry = new BoxColliderGeometry();
+                        break;
+                    default:
+                        MREAPI.Logger.LogError($"Failed to deserialize collider geometry.  Invalid collider type <{colliderType}>.");
+                        break;
+                }
+
+                serializer.Populate(jObject.CreateReader(), colliderGeometry);
+
+                return colliderGeometry;
+            }
+            catch (Exception e)
+            {
+                MREAPI.Logger.LogError($"Failed to create collider geometry from json.  Exception: {e.Message}\nStack Trace: {e.StackTrace}");
+                throw;
+            }
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value);
+        }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/IPatchable.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/IPatchable.cs
@@ -4,6 +4,6 @@ namespace MixedRealityExtension.Patching
 {
     public interface IPatchable
     {
-        bool IsPatched();
+
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Patching.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Patching.cs
@@ -8,8 +8,7 @@ namespace MixedRealityExtension.Patching
 {
     internal static class PatchingUtils
     {
-        // TODO @tombu - Look in to making this an extension method.
-        public static bool IsPatched<T>(T patch) where T : IPatchable
+        public static bool IsPatched<T>(this T patch) where T : IPatchable
         {
             var properties = patch.GetType().GetProperties();
             foreach (var property in properties)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ActorPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ActorPatch.cs
@@ -16,6 +16,9 @@ namespace MixedRealityExtension.Patching.Types
         public RigidBodyPatch RigidBody { get; set; }
 
         [PatchProperty]
+        public ColliderPatch Collider { get; set; }
+
+        [PatchProperty]
         public LightPatch Light { get; set; }
 
         [PatchProperty]

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColliderPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColliderPatch.cs
@@ -1,0 +1,25 @@
+﻿using MixedRealityExtension.Core;
+using MixedRealityExtension.Core.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MixedRealityExtension.Patching.Types
+{
+    public class ColliderPatch : IPatchable
+    {
+        [PatchProperty]
+        public bool? IsEnabled { get; set; }
+
+        [PatchProperty]
+        public bool? IsTrigger { get; set; }
+
+        //[PatchProperty]
+        //public CollisionLayer? CollisionLayer { get; set; }
+
+        [PatchProperty]
+        public ColliderGeometry ColliderGeometry { get; set; }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColliderPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColliderPatch.cs
@@ -1,10 +1,7 @@
-﻿using MixedRealityExtension.Core;
-using MixedRealityExtension.Core.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MixedRealityExtension.Core;
 
 namespace MixedRealityExtension.Patching.Types
 {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColorPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ColorPatch.cs
@@ -53,10 +53,5 @@ namespace MixedRealityExtension.Patching.Types
                     A.Equals(other.A);
             }
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/LightPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/LightPatch.cs
@@ -37,10 +37,5 @@ namespace MixedRealityExtension.Patching.Types
             Intensity = light.intensity;
             SpotAngle = light.spotAngle;
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/MixedRealityExtensionObjectPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/MixedRealityExtensionObjectPatch.cs
@@ -23,10 +23,5 @@ namespace MixedRealityExtension.Patching.Types
         {
             this.Id = id;
         }
-	
-		public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/QuaternionPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/QuaternionPatch.cs
@@ -78,10 +78,5 @@ namespace MixedRealityExtension.Patching.Types
                     W.Equals(other.W);
             }
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/RigidBodyPatch.cs
@@ -116,10 +116,5 @@ namespace MixedRealityExtension.Patching.Types
             UseGravity = rigidbody.useGravity;
             ConstraintFlags = (MRERigidBodyConstraints)Enum.Parse(typeof(MRERigidBodyConstraints), rigidbody.constraints.ToString());
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/TextPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/TextPatch.cs
@@ -43,10 +43,5 @@ namespace MixedRealityExtension.Patching.Types
 			Font = text.Font;
 			Color = new ColorPatch(text.Color);
 		}
-
-		public bool IsPatched()
-		{
-			return PatchingUtils.IsPatched(this);
-		}
 	}
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/TransformPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/TransformPatch.cs
@@ -26,10 +26,5 @@ namespace MixedRealityExtension.Patching.Types
             this.Rotation = new QuaternionPatch(rotation);
             this.Scale = new Vector3Patch(scale);
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
@@ -27,10 +27,5 @@ namespace MixedRealityExtension.Patching.Types
         {
             Name = user.Name;
         }
-
-        public bool IsPatched()
-        {
-            return false;
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/Vector2Patch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/Vector2Patch.cs
@@ -53,10 +53,5 @@ namespace MixedRealityExtension.Patching.Types
                     Y.Equals(other.Y);
             }
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/Vector3Patch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/Vector3Patch.cs
@@ -60,10 +60,5 @@ namespace MixedRealityExtension.Patching.Types
                     Z.Equals(other.Z);
             }
         }
-
-        public bool IsPatched()
-        {
-            return PatchingUtils.IsPatched(this);
-        }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IEngineConstants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IEngineConstants.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+namespace MixedRealityExtension.PluginInterfaces
+{
+    public struct MRELayers
+    {
+        int Object;
+        int Environment;
+        int Hologram;
+    }
+
+    public interface IEngineConstants
+    {
+        MRELayers Layers { get; }
+    }
+}


### PR DESCRIPTION
Added in the backing support on Unity for setting and resetting a collider on an actor.  There is also logic adding in the collider to the initial actor patch upon creation for the case that the newly created actor already has a collider of type box, sphere or mesh.  This makes the app aware that an actor has an existing collider on an actor in the case it was there at the time of creation.

**_Note: Contains a slight cleanup effort around the IsPatched methods for our patching system._**: