### PR TITLE
fix sync for looping sounds after the first playthrough has completed

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -1027,17 +1027,25 @@ namespace MixedRealityExtension.App
                     var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as AudioClip;
                     if (audioClip != null)
                     {
-                        var soundInstance = actor.gameObject.AddComponent<AudioSource>();
-                        soundInstance.clip = audioClip;
-                        soundInstance.time = payload.StartTimeOffset;
-                        soundInstance.spatialBlend = 1.0f;
-                        soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
-                        soundInstance.minDistance = 1.0f;
-                        soundInstance.maxDistance = 1000000.0f;
-                        ApplySoundStateOptions(soundInstance, payload.Options);
-                        soundInstance.Play();
-                        _soundInstances.Add(payload.Id, soundInstance);
-                        _unpausedSoundInstances.Add(payload.Id);
+                        float offset = payload.StartTimeOffset;
+                        if (payload.Options.Looping != null && payload.Options.Looping.Value)
+                        {
+                            offset = payload.StartTimeOffset%audioClip.length;
+                        }
+                        if (offset < audioClip.length)
+                        {
+                            var soundInstance = actor.gameObject.AddComponent<AudioSource>();
+                            soundInstance.clip = audioClip;
+                            soundInstance.time = offset;
+                            soundInstance.spatialBlend = 1.0f;
+                            soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
+                            soundInstance.minDistance = 1.0f;
+                            soundInstance.maxDistance = 1000000.0f;
+                            ApplySoundStateOptions(soundInstance, payload.Options);
+                            soundInstance.Play();
+                            _soundInstances.Add(payload.Id, soundInstance);
+                            _unpausedSoundInstances.Add(payload.Id);
+                        }
                     }
                 }
                 else

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -988,13 +988,13 @@ namespace MixedRealityExtension.App
             //garbage collect expired sounds, one per frame
             if (_soundStoppedCheckIndex >= _unpausedSoundInstances.Count)
             {
-                _soundStoppedCheckIndex  = 0;
+                _soundStoppedCheckIndex = 0;
             }
             else
             {
                 var id = _unpausedSoundInstances[_soundStoppedCheckIndex];
                 AudioSource soundInstance;
-                if(_soundInstances.TryGetValue(id, out soundInstance) && !soundInstance.isPlaying)
+                if (_soundInstances.TryGetValue(id, out soundInstance) && !soundInstance.isPlaying)
                 {
                     DestroySoundInstance(soundInstance, id);
                 }
@@ -1030,7 +1030,7 @@ namespace MixedRealityExtension.App
                         float offset = payload.StartTimeOffset;
                         if (payload.Options.Looping != null && payload.Options.Looping.Value)
                         {
-                            offset = payload.StartTimeOffset%audioClip.length;
+                            offset = payload.StartTimeOffset % audioClip.length;
                         }
                         if (offset < audioClip.length)
                         {


### PR DESCRIPTION
Unity quirk: if an audiosource time is larger than the audioclip length, it doesn't automatically calculate the proper time in the middle of the loop. This works around that quirk

This also doesn't create a soundinstance if it's a non-looping sound that would have ended already - it would have played once, even though it was supposed to not play at all-