### PR TITLE
fix sound unity exceptions on actor destroy

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -947,6 +947,16 @@ namespace MixedRealityExtension.App
         private List<Guid> _unpausedSoundInstances = new List<Guid>();
         private int _soundStoppedCheckIndex = 0;
 
+        public void RemoveSoundInstancesForActor(GameObject gameObject)
+        {
+            foreach (KeyValuePair<Guid, AudioSource> soundInstance in _soundInstances)
+            {
+                if(soundInstance.Value.gameObject == gameObject)
+                {
+                    DestroySoundInstance(soundInstance.Value, soundInstance.Key);
+                }
+            }
+        }
         private void ApplySoundStateOptions(AudioSource soundInstance, SoundStateOptions options, Guid id)
         {
             if (options != null)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -173,6 +173,10 @@ namespace MixedRealityExtension.Core
         internal void Destroy()
         {
             CleanUp();
+            if(gameObject.GetComponent<AudioSource>() != null)
+            {
+                App.RemoveSoundInstancesForActor(gameObject);
+            }
             Destroy(gameObject);
         }
 


### PR DESCRIPTION
when an actor is destroyed, unity's gameobject destroy automatically destroys all audiosources. we need to clean up our lists tracking these instances. This is not fast, but functional.