### PR TITLE
[Unity] Move message queuing to the client

### DIFF
--- a/MRETestBed/ProjectSettings/ProjectSettings.asset
+++ b/MRETestBed/ProjectSettings/ProjectSettings.asset
@@ -616,7 +616,6 @@ PlayerSettings:
   m_MobileRenderingPath: 1
   metroPackageName: MRETestBed
   metroPackageVersion: 1.0.0.0
-  metroCertificatePath: Assets\WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: DefaultCompany
   metroCertificateIssuer: DefaultCompany

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -133,7 +133,7 @@ namespace MixedRealityExtension.Assets
         }
 
         [CommandHandler(typeof(LoadAssets))]
-        private async Task LoadAssets(LoadAssets payload)
+        private async Task LoadAssets(LoadAssets payload, Action onCompleteCallback)
         {
             LoaderFunction loader;
 
@@ -169,6 +169,7 @@ namespace MixedRealityExtension.Assets
                         Assets = assets ?? new Asset[] { }
                     }
                 });
+                onCompleteCallback?.Invoke();
             }
         }
 
@@ -280,7 +281,7 @@ namespace MixedRealityExtension.Assets
         }
 
         [CommandHandler(typeof(AssetUpdate))]
-        internal void OnAssetUpdate(AssetUpdate payload)
+        internal void OnAssetUpdate(AssetUpdate payload, Action onCompleteCallback)
         {
             var def = payload.Asset;
             var asset = MREAPI.AppsAPI.AssetCache.GetAsset(def.Id);
@@ -310,10 +311,11 @@ namespace MixedRealityExtension.Assets
             {
                 MREAPI.Logger.LogError($"Asset {def.Id} is not patchable, or not of the right type!");
             }
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(CreateAsset))]
-        internal async void OnCreateAsset(CreateAsset payload)
+        internal async void OnCreateAsset(CreateAsset payload, Action onCompleteCallback)
         {
             var def = payload.Definition;
             var response = new AssetsLoaded();
@@ -325,7 +327,7 @@ namespace MixedRealityExtension.Assets
 
                 OnAssetUpdate(new AssetUpdate() {
                     Asset = def
-                });
+                }, null);
 
                 response.Assets = new Asset[]{ new Asset()
                 {
@@ -347,7 +349,7 @@ namespace MixedRealityExtension.Assets
 
                     OnAssetUpdate(new AssetUpdate() {
                         Asset = def
-                    });
+                    }, null);
                     assignTextureToQueuedMaterials(def.Id);
 
                     response.Assets = new Asset[] { new Asset()
@@ -399,6 +401,8 @@ namespace MixedRealityExtension.Assets
                 ReplyToId = payload.MessageId,
                 Payload = response
             });
+
+            onCompleteCallback?.Invoke();
         }
 
         #region Async texture management

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -166,17 +166,11 @@ namespace MixedRealityExtension.Core
 
         internal void ExecuteRigidBodyCommands(RigidBodyCommands commandPayload, Action onCompleteCallback)
         {
-            try
+            foreach (var command in commandPayload.CommandPayloads.OfType<ICommandPayload>())
             {
-                foreach (var command in commandPayload.CommandPayloads.OfType<ICommandPayload>())
-                {
-                    App.ExecuteCommandPayload(this, command, null);
-                }
+                App.ExecuteCommandPayload(this, command, null);
             }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            onCompleteCallback?.Invoke();
         }
 
         internal void Destroy()
@@ -861,42 +855,24 @@ namespace MixedRealityExtension.Core
         [CommandHandler(typeof(ActorCorrection))]
         private void OnActorCorrection(ActorCorrection payload, Action onCompleteCallback)
         {
-            try
-            {
-                // TODO: Interpolate this change onto the actor.
-                SynchronizeEngine(payload.Actor);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            // TODO: Interpolate this change onto the actor.
+            SynchronizeEngine(payload.Actor);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(ActorUpdate))]
         private void OnActorUpdate(ActorUpdate payload, Action onCompleteCallback)
         {
-            try
-            {
-                SynchronizeEngine(payload.Actor);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            SynchronizeEngine(payload.Actor);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(UpdateSubscriptions))]
         private void OnUpdateSubscriptions(UpdateSubscriptions payload, Action onCompleteCallback)
         {
-            try
-            {
-                RemoveSubscriptions(payload.Removes);
-                AddSubscriptions(payload.Adds);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RemoveSubscriptions(payload.Removes);
+            AddSubscriptions(payload.Adds);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RigidBodyCommands))]
@@ -922,228 +898,155 @@ namespace MixedRealityExtension.Core
         [CommandHandler(typeof(DEPRECATED_StartAnimation))]
         private void OnStartAnimation(DEPRECATED_StartAnimation payload, Action onCompleteCallback)
         {
-            try
-            {
-                bool paused = payload.Paused.HasValue && payload.Paused.Value;
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, !paused);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            bool paused = payload.Paused.HasValue && payload.Paused.Value;
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, !paused);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_StopAnimation))]
         private void OnStopAnimation(DEPRECATED_StopAnimation payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, false);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, false);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_PauseAnimation))]
         private void OnPauseAnimation(DEPRECATED_PauseAnimation payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, time: null, speed: null, false);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, time: null, speed: null, false);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_ResumeAnimation))]
         private void OnResumeAnimation(DEPRECATED_ResumeAnimation payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, time: null, speed: null, true);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, time: null, speed: null, true);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_ResetAnimation))]
         private void OnResetAnimation(DEPRECATED_ResetAnimation payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, time: 0, speed: null, null);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, time: 0, speed: null, null);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_EnableRigidBody))]
         private void OnEnableRigidBody(DEPRECATED_EnableRigidBody payload, Action onCompleteCallback)
         {
-            try
-            {
-                OperationResult result = EnableRigidBody(payload.RigidBody);
-                App.Protocol.Send(result, payload.MessageId);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            OperationResult result = EnableRigidBody(payload.RigidBody);
+            App.Protocol.Send(result, payload.MessageId);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_EnableLight))]
         private void OnEnableLight(DEPRECATED_EnableLight payload, Action onCompleteCallback)
         {
-            try
-            {
-                OperationResult result = EnableLight(payload.Light);
-                App.Protocol.Send(result, payload.MessageId);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            OperationResult result = EnableLight(payload.Light);
+            App.Protocol.Send(result, payload.MessageId);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(DEPRECATED_EnableText))]
         private void OnEnableText(DEPRECATED_EnableText payload, Action onCompleteCallback)
         {
-            try
-            {
-                OperationResult result = EnableText(payload.Text);
-                App.Protocol.Send(result, payload.MessageId);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            OperationResult result = EnableText(payload.Text);
+            App.Protocol.Send(result, payload.MessageId);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(SetAnimationState))]
         private void OnSetAnimationState(SetAnimationState payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .SetAnimationState(payload.AnimationName, payload.State.Time, payload.State.Speed, payload.State.Enabled);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .SetAnimationState(payload.AnimationName, payload.State.Time, payload.State.Speed, payload.State.Enabled);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(SetSoundState))]
         private void OnSetSoundState(SetSoundState payload, Action onCompleteCallback)
         {
-            try
+            if (payload.SoundCommand == SoundCommand.Start)
             {
-                if (payload.SoundCommand == SoundCommand.Start)
+                var obj = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId);
+                var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as AudioClip;
+                if (audioClip != null)
                 {
-                    var obj = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId);
-                    var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as AudioClip;
-                    if (audioClip != null)
+                    float offset = payload.StartTimeOffset;
+                    if (payload.Options.Looping != null && payload.Options.Looping.Value)
                     {
-                        float offset = payload.StartTimeOffset;
-                        if (payload.Options.Looping != null && payload.Options.Looping.Value)
+                        offset = payload.StartTimeOffset % audioClip.length;
+                    }
+                    if (offset < audioClip.length)
+                    {
+                        var soundInstance = gameObject.AddComponent<AudioSource>();
+                        soundInstance.clip = audioClip;
+                        soundInstance.time = offset;
+                        soundInstance.spatialBlend = 1.0f;
+                        soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
+                        soundInstance.minDistance = 1.0f;
+                        soundInstance.maxDistance = 1000000.0f;
+                        App.SoundManager.TrackUnpauseSound(payload.Id);
+                        App.SoundManager.ApplySoundStateOptions(soundInstance, payload.Options, payload.Id);
+                        if (payload.Options.paused == null || payload.Options.paused.Value == false)
                         {
-                            offset = payload.StartTimeOffset % audioClip.length;
+                            soundInstance.Play();
                         }
-                        if (offset < audioClip.length)
-                        {
-                            var soundInstance = gameObject.AddComponent<AudioSource>();
-                            soundInstance.clip = audioClip;
-                            soundInstance.time = offset;
-                            soundInstance.spatialBlend = 1.0f;
-                            soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
-                            soundInstance.minDistance = 1.0f;
-                            soundInstance.maxDistance = 1000000.0f;
-                            App.SoundManager.TrackUnpauseSound(payload.Id);
+                        App.SoundManager.AddSoundInstance(payload.Id, soundInstance);
+                    }
+                }
+            }
+            else
+            {
+                if (App.SoundManager.TryGetSoundInstance(payload.Id, out AudioSource soundInstance))
+                {
+                    switch (payload.SoundCommand)
+                    {
+                        case SoundCommand.Stop:
+                            App.SoundManager.DestroySoundInstance(soundInstance, payload.Id);
+                            break;
+                        case SoundCommand.Update:
                             App.SoundManager.ApplySoundStateOptions(soundInstance, payload.Options, payload.Id);
-                            if (payload.Options.paused == null || payload.Options.paused.Value == false)
-                            {
-                                soundInstance.Play();
-                            }
-                            App.SoundManager.AddSoundInstance(payload.Id, soundInstance);
-                        }
-                    }
-                }
-                else
-                {
-                    AudioSource soundInstance;
-                    if (App.SoundManager.TryGetSoundInstance(payload.Id, out soundInstance))
-                    {
-                        switch (payload.SoundCommand)
-                        {
-                            case SoundCommand.Stop:
-                                App.SoundManager.DestroySoundInstance(soundInstance, payload.Id);
-                                break;
-                            case SoundCommand.Update:
-                                App.SoundManager.ApplySoundStateOptions(soundInstance, payload.Options, payload.Id);
-                                break;
-                        }
+                            break;
                     }
                 }
             }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(InterpolateActor))]
         private void OnInterpolateActor(InterpolateActor payload, Action onCompleteCallback)
         {
-            try
-            {
-                GetOrCreateActorComponent<AnimationComponent>()
-                    .Interpolate(
-                        payload.Value,
-                        payload.AnimationName,
-                        payload.Duration,
-                        payload.Curve,
-                        payload.Enabled);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            GetOrCreateActorComponent<AnimationComponent>()
+                .Interpolate(
+                    payload.Value,
+                    payload.AnimationName,
+                    payload.Duration,
+                    payload.Curve,
+                    payload.Enabled);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(SetBehavior))]
         private void OnSetBehavior(SetBehavior payload, Action onCompleteCallback)
         {
-            try
-            {
-                var behaviorComponent = GetOrCreateActorComponent<BehaviorComponent>();
+            var behaviorComponent = GetOrCreateActorComponent<BehaviorComponent>();
 
-                if (payload.BehaviorType == BehaviorType.None && behaviorComponent.ContainsBehaviorHandler())
-                {
-                    behaviorComponent.ClearBehaviorHandler();
-                }
-                else
-                {
-                    var handler = BehaviorHandlerFactory.CreateBehaviorHandler(payload.BehaviorType, this, new WeakReference<MixedRealityExtensionApp>(App));
-                    behaviorComponent.SetBehaviorHandler(handler);
-                }
-            }
-            finally
+            if (payload.BehaviorType == BehaviorType.None && behaviorComponent.ContainsBehaviorHandler())
             {
-                onCompleteCallback?.Invoke();
+                behaviorComponent.ClearBehaviorHandler();
             }
+            else
+            {
+                var handler = BehaviorHandlerFactory.CreateBehaviorHandler(payload.BehaviorType, this, new WeakReference<MixedRealityExtensionApp>(App));
+                behaviorComponent.SetBehaviorHandler(handler);
+            }
+            onCompleteCallback?.Invoke();
         }
 
         #endregion
@@ -1153,81 +1056,45 @@ namespace MixedRealityExtension.Core
         [CommandHandler(typeof(RBMovePosition))]
         private void OnRBMovePosition(RBMovePosition payload, Action onCompleteCallback)
         {
-            try
-            {
-                RigidBody?.RigidBodyMovePosition(new MWVector3().ApplyPatch(payload.Position));
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RigidBody?.RigidBodyMovePosition(new MWVector3().ApplyPatch(payload.Position));
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RBMoveRotation))]
         private void OnRBMoveRotation(RBMoveRotation payload, Action onCompleteCallback)
         {
-            try
-            {
-                RigidBody?.RigidBodyMoveRotation(new MWQuaternion().ApplyPatch(payload.Rotation));
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RigidBody?.RigidBodyMoveRotation(new MWQuaternion().ApplyPatch(payload.Rotation));
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RBAddForce))]
         private void OnRBAddForce(RBAddForce payload, Action onCompleteCallback)
         {
-            try
-            {
-                RigidBody?.RigidBodyAddForce(new MWVector3().ApplyPatch(payload.Force));
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RigidBody?.RigidBodyAddForce(new MWVector3().ApplyPatch(payload.Force));
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RBAddForceAtPosition))]
         private void OnRBAddForceAtPosition(RBAddForceAtPosition payload, Action onCompleteCallback)
         {
-            try
-            {
-                var force = new MWVector3().ApplyPatch(payload.Force);
-                var position = new MWVector3().ApplyPatch(payload.Position);
-                RigidBody?.RigidBodyAddForceAtPosition(force, position);
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            var force = new MWVector3().ApplyPatch(payload.Force);
+            var position = new MWVector3().ApplyPatch(payload.Position);
+            RigidBody?.RigidBodyAddForceAtPosition(force, position);
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RBAddTorque))]
         private void OnRBAddTorque(RBAddTorque payload, Action onCompleteCallback)
         {
-            try
-            {
-                RigidBody?.RigidBodyAddTorque(new MWVector3().ApplyPatch(payload.Torque));
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RigidBody?.RigidBodyAddTorque(new MWVector3().ApplyPatch(payload.Torque));
+            onCompleteCallback?.Invoke();
         }
 
         [CommandHandler(typeof(RBAddRelativeTorque))]
         private void OnRBAddRelativeTorque(RBAddRelativeTorque payload, Action onCompleteCallback)
         {
-            try
-            {
-                RigidBody?.RigidBodyAddRelativeTorque(new MWVector3().ApplyPatch(payload.RelativeTorque));
-            }
-            finally
-            {
-                onCompleteCallback?.Invoke();
-            }
+            RigidBody?.RigidBodyAddRelativeTorque(new MWVector3().ApplyPatch(payload.RelativeTorque));
+            onCompleteCallback?.Invoke();
         }
 
         #endregion

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using MixedRealityExtension.API;
+using MixedRealityExtension.App;
+using MixedRealityExtension.Behaviors;
 using MixedRealityExtension.Core.Components;
 using MixedRealityExtension.Core.Interfaces;
 using MixedRealityExtension.Core.Types;
@@ -66,8 +68,8 @@ namespace MixedRealityExtension.Core
         internal Light Light { get; private set; }
 
         internal IText Text { get; private set; }
-		
-		internal Collider Collider { get; private set; }
+
+        internal Collider Collider { get; private set; }
 
         internal Attachment Attachment { get; } = new Attachment();
         private Attachment _cachedAttachment = new Attachment();
@@ -162,11 +164,18 @@ namespace MixedRealityExtension.Core
             _updateActions.Enqueue((actor) => ApplyPatch(actorPatch));
         }
 
-        internal void ExecuteRigidBodyCommands(RigidBodyCommands commandPayload)
+        internal void ExecuteRigidBodyCommands(RigidBodyCommands commandPayload, Action onCompleteCallback)
         {
-            foreach (var command in commandPayload.CommandPayloads.OfType<ICommandPayload>())
+            try
             {
-                App.ExecuteCommandPayload(this, command);
+                foreach (var command in commandPayload.CommandPayloads.OfType<ICommandPayload>())
+                {
+                    App.ExecuteCommandPayload(this, command, null);
+                }
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
             }
         }
 
@@ -847,44 +856,378 @@ namespace MixedRealityExtension.Core
 
         #endregion
 
+        #region Command Handlers
+
+        [CommandHandler(typeof(ActorCorrection))]
+        private void OnActorCorrection(ActorCorrection payload, Action onCompleteCallback)
+        {
+            try
+            {
+                // TODO: Interpolate this change onto the actor.
+                SynchronizeEngine(payload.Actor);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(ActorUpdate))]
+        private void OnActorUpdate(ActorUpdate payload, Action onCompleteCallback)
+        {
+            try
+            {
+                SynchronizeEngine(payload.Actor);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(UpdateSubscriptions))]
+        private void OnUpdateSubscriptions(UpdateSubscriptions payload, Action onCompleteCallback)
+        {
+            try
+            {
+                RemoveSubscriptions(payload.Removes);
+                AddSubscriptions(payload.Adds);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(RigidBodyCommands))]
+        private void OnRigidBodyCommands(RigidBodyCommands payload, Action onCompleteCallback)
+        {
+            ExecuteRigidBodyCommands(payload, onCompleteCallback);
+        }
+
+        [CommandHandler(typeof(CreateAnimation))]
+        private void OnCreateAnimation(CreateAnimation payload, Action onCompleteCallback)
+        {
+            GetOrCreateActorComponent<AnimationComponent>()
+                .CreateAnimation(
+                    payload.AnimationName,
+                    payload.Keyframes,
+                    payload.Events,
+                    payload.WrapMode,
+                    payload.InitialState,
+                    isInternal: false,
+                    onCreatedCallback: () => onCompleteCallback?.Invoke());
+        }
+
+        [CommandHandler(typeof(DEPRECATED_StartAnimation))]
+        private void OnStartAnimation(DEPRECATED_StartAnimation payload, Action onCompleteCallback)
+        {
+            try
+            {
+                bool paused = payload.Paused.HasValue && payload.Paused.Value;
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, !paused);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_StopAnimation))]
+        private void OnStopAnimation(DEPRECATED_StopAnimation payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, payload.AnimationTime, speed: null, false);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_PauseAnimation))]
+        private void OnPauseAnimation(DEPRECATED_PauseAnimation payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, time: null, speed: null, false);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_ResumeAnimation))]
+        private void OnResumeAnimation(DEPRECATED_ResumeAnimation payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, time: null, speed: null, true);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_ResetAnimation))]
+        private void OnResetAnimation(DEPRECATED_ResetAnimation payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, time: 0, speed: null, null);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_EnableRigidBody))]
+        private void OnEnableRigidBody(DEPRECATED_EnableRigidBody payload, Action onCompleteCallback)
+        {
+            try
+            {
+                OperationResult result = EnableRigidBody(payload.RigidBody);
+                App.Protocol.Send(result, payload.MessageId);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_EnableLight))]
+        private void OnEnableLight(DEPRECATED_EnableLight payload, Action onCompleteCallback)
+        {
+            try
+            {
+                OperationResult result = EnableLight(payload.Light);
+                App.Protocol.Send(result, payload.MessageId);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(DEPRECATED_EnableText))]
+        private void OnEnableText(DEPRECATED_EnableText payload, Action onCompleteCallback)
+        {
+            try
+            {
+                OperationResult result = EnableText(payload.Text);
+                App.Protocol.Send(result, payload.MessageId);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(SetAnimationState))]
+        private void OnSetAnimationState(SetAnimationState payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .SetAnimationState(payload.AnimationName, payload.State.Time, payload.State.Speed, payload.State.Enabled);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(SetSoundState))]
+        private void OnSetSoundState(SetSoundState payload, Action onCompleteCallback)
+        {
+            try
+            {
+                if (payload.SoundCommand == SoundCommand.Start)
+                {
+                    var obj = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId);
+                    var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as AudioClip;
+                    if (audioClip != null)
+                    {
+                        float offset = payload.StartTimeOffset;
+                        if (payload.Options.Looping != null && payload.Options.Looping.Value)
+                        {
+                            offset = payload.StartTimeOffset % audioClip.length;
+                        }
+                        if (offset < audioClip.length)
+                        {
+                            var soundInstance = gameObject.AddComponent<AudioSource>();
+                            soundInstance.clip = audioClip;
+                            soundInstance.time = offset;
+                            soundInstance.spatialBlend = 1.0f;
+                            soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
+                            soundInstance.minDistance = 1.0f;
+                            soundInstance.maxDistance = 1000000.0f;
+                            App.SoundManager.TrackUnpauseSound(payload.Id);
+                            App.SoundManager.ApplySoundStateOptions(soundInstance, payload.Options, payload.Id);
+                            if (payload.Options.paused == null || payload.Options.paused.Value == false)
+                            {
+                                soundInstance.Play();
+                            }
+                            App.SoundManager.AddSoundInstance(payload.Id, soundInstance);
+                        }
+                    }
+                }
+                else
+                {
+                    AudioSource soundInstance;
+                    if (App.SoundManager.TryGetSoundInstance(payload.Id, out soundInstance))
+                    {
+                        switch (payload.SoundCommand)
+                        {
+                            case SoundCommand.Stop:
+                                App.SoundManager.DestroySoundInstance(soundInstance, payload.Id);
+                                break;
+                            case SoundCommand.Update:
+                                App.SoundManager.ApplySoundStateOptions(soundInstance, payload.Options, payload.Id);
+                                break;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(InterpolateActor))]
+        private void OnInterpolateActor(InterpolateActor payload, Action onCompleteCallback)
+        {
+            try
+            {
+                GetOrCreateActorComponent<AnimationComponent>()
+                    .Interpolate(
+                        payload.Value,
+                        payload.AnimationName,
+                        payload.Duration,
+                        payload.Curve,
+                        payload.Enabled);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        [CommandHandler(typeof(SetBehavior))]
+        private void OnSetBehavior(SetBehavior payload, Action onCompleteCallback)
+        {
+            try
+            {
+                var behaviorComponent = GetOrCreateActorComponent<BehaviorComponent>();
+
+                if (payload.BehaviorType == BehaviorType.None && behaviorComponent.ContainsBehaviorHandler())
+                {
+                    behaviorComponent.ClearBehaviorHandler();
+                }
+                else
+                {
+                    var handler = BehaviorHandlerFactory.CreateBehaviorHandler(payload.BehaviorType, this, new WeakReference<MixedRealityExtensionApp>(App));
+                    behaviorComponent.SetBehaviorHandler(handler);
+                }
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
+        }
+
+        #endregion
+
         #region Command Handlers - Rigid Body Commands
 
         [CommandHandler(typeof(RBMovePosition))]
-        private void OnRBMovePosition(RBMovePosition payload)
+        private void OnRBMovePosition(RBMovePosition payload, Action onCompleteCallback)
         {
-            RigidBody?.RigidBodyMovePosition(new MWVector3().ApplyPatch(payload.Position));
+            try
+            {
+                RigidBody?.RigidBodyMovePosition(new MWVector3().ApplyPatch(payload.Position));
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         [CommandHandler(typeof(RBMoveRotation))]
-        private void OnRBMoveRotation(RBMoveRotation payload)
+        private void OnRBMoveRotation(RBMoveRotation payload, Action onCompleteCallback)
         {
-            RigidBody?.RigidBodyMoveRotation(new MWQuaternion().ApplyPatch(payload.Rotation));
+            try
+            {
+                RigidBody?.RigidBodyMoveRotation(new MWQuaternion().ApplyPatch(payload.Rotation));
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         [CommandHandler(typeof(RBAddForce))]
-        private void OnRBAddForce(RBAddForce payload)
+        private void OnRBAddForce(RBAddForce payload, Action onCompleteCallback)
         {
-            RigidBody?.RigidBodyAddForce(new MWVector3().ApplyPatch(payload.Force));
+            try
+            {
+                RigidBody?.RigidBodyAddForce(new MWVector3().ApplyPatch(payload.Force));
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         [CommandHandler(typeof(RBAddForceAtPosition))]
-        private void OnRBAddForceAtPosition(RBAddForceAtPosition payload)
+        private void OnRBAddForceAtPosition(RBAddForceAtPosition payload, Action onCompleteCallback)
         {
-            var force = new MWVector3().ApplyPatch(payload.Force);
-            var position = new MWVector3().ApplyPatch(payload.Position);
-            RigidBody?.RigidBodyAddForceAtPosition(force, position);
+            try
+            {
+                var force = new MWVector3().ApplyPatch(payload.Force);
+                var position = new MWVector3().ApplyPatch(payload.Position);
+                RigidBody?.RigidBodyAddForceAtPosition(force, position);
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         [CommandHandler(typeof(RBAddTorque))]
-        private void OnRBAddTorque(RBAddTorque payload)
+        private void OnRBAddTorque(RBAddTorque payload, Action onCompleteCallback)
         {
-            RigidBody?.RigidBodyAddTorque(new MWVector3().ApplyPatch(payload.Torque));
+            try
+            {
+                RigidBody?.RigidBodyAddTorque(new MWVector3().ApplyPatch(payload.Torque));
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         [CommandHandler(typeof(RBAddRelativeTorque))]
-        private void OnRBAddRelativeTorque(RBAddRelativeTorque payload)
+        private void OnRBAddRelativeTorque(RBAddRelativeTorque payload, Action onCompleteCallback)
         {
-            RigidBody?.RigidBodyAddRelativeTorque(new MWVector3().ApplyPatch(payload.RelativeTorque));
+            try
+            {
+                RigidBody?.RigidBodyAddRelativeTorque(new MWVector3().ApplyPatch(payload.RelativeTorque));
+            }
+            finally
+            {
+                onCompleteCallback?.Invoke();
+            }
         }
 
         #endregion

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -176,6 +176,10 @@ namespace MixedRealityExtension.Core
         internal void Destroy()
         {
             CleanUp();
+            if (gameObject.GetComponent<AudioSource>() != null)
+            {
+                App.SoundManager.RemoveSoundInstancesForActor(gameObject);
+            }
             Destroy(gameObject);
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
@@ -41,7 +41,7 @@ namespace MixedRealityExtension.Core
 
         public void Update()
         {
-            if (busy)
+            if (activeCommand != null || queue.Count == 0)
             {
                 return;
             }
@@ -51,22 +51,16 @@ namespace MixedRealityExtension.Core
                 actor = app.FindActor(actorId) as Actor;
             }
 
-            if (actor != null && queue.Count > 0)
+            if (actor != null)
             {
                 activeCommand = queue.Dequeue();
-                app.ExecuteCommandPayload(actor, activeCommand.Payload, OnCommandComplete);
+                app.ExecuteCommandPayload(actor, activeCommand.Payload, () =>
+                {
+                    activeCommand?.OnCompleteCallback?.Invoke();
+                    activeCommand = null;
+                    Update();
+                });
             }
-        }
-
-        #endregion
-
-        #region Private Methods
-
-        private void OnCommandComplete()
-        {
-            activeCommand?.OnCompleteCallback?.Invoke();
-            activeCommand = null;
-            Update();
         }
 
         #endregion
@@ -78,12 +72,6 @@ namespace MixedRealityExtension.Core
             public NetworkCommandPayload Payload { get; set; }
             public Action OnCompleteCallback { get; set; }
         }
-
-        #endregion
-
-        #region Private Accessors
-
-        private bool busy => activeCommand != null;
 
         #endregion
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
@@ -1,0 +1,100 @@
+﻿using MixedRealityExtension.App;
+using MixedRealityExtension.Core.Interfaces;
+using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MixedRealityExtension.Core
+{
+    internal class ActorCommandQueue
+    {
+        #region Public Accessors
+
+        public int Count => queue.Count;
+
+        #endregion
+
+        #region Constructor
+
+        public ActorCommandQueue(Guid actorId, MixedRealityExtensionApp app)
+        {
+            this.actorId = actorId;
+            this.app = app;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Enqueue(NetworkCommandPayload payload, Action onCompleteCallback)
+        {
+            queue.Enqueue(new QueuedCommand()
+            {
+                Payload = payload,
+                OnCompleteCallback = onCompleteCallback
+            });
+        }
+
+        public void Update()
+        {
+            if (busy)
+            {
+                return;
+            }
+
+            if (actor == null)
+            {
+                actor = app.FindActor(actorId) as Actor;
+            }
+
+            if (actor != null && queue.Count > 0)
+            {
+                activeCommand = queue.Dequeue();
+                app.ExecuteCommandPayload(actor, activeCommand.Payload, OnCommandComplete);
+            }
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void OnCommandComplete()
+        {
+            activeCommand?.OnCompleteCallback?.Invoke();
+            activeCommand = null;
+            Update();
+        }
+
+        #endregion
+
+        #region Private Types
+
+        private class QueuedCommand
+        {
+            public NetworkCommandPayload Payload { get; set; }
+            public Action OnCompleteCallback { get; set; }
+        }
+
+        #endregion
+
+        #region Private Accessors
+
+        private bool busy => activeCommand != null;
+
+        #endregion
+
+        #region Private Fields
+
+        private QueuedCommand activeCommand;
+        private Actor actor;
+        private readonly Guid actorId;
+        private readonly MixedRealityExtensionApp app;
+        private readonly Queue<QueuedCommand> queue = new Queue<QueuedCommand>();
+
+        #endregion
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorCommandQueue.cs
@@ -54,12 +54,21 @@ namespace MixedRealityExtension.Core
             if (actor != null)
             {
                 activeCommand = queue.Dequeue();
-                app.ExecuteCommandPayload(actor, activeCommand.Payload, () =>
+                try
                 {
-                    activeCommand?.OnCompleteCallback?.Invoke();
+                    app.ExecuteCommandPayload(actor, activeCommand.Payload, () =>
+                    {
+                        activeCommand?.OnCompleteCallback?.Invoke();
+                        activeCommand = null;
+                        Update();
+                    });
+                }
+                catch
+                {
+                    // In case of error, clear activeCommand so that queue processing isn't stalled forever.
                     activeCommand = null;
-                    Update();
-                });
+                    throw;
+                }
             }
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -146,10 +146,9 @@ namespace MixedRealityExtension.Core
         #region Command Handlers
 
         [CommandHandler(typeof(ActorCorrection))]
-        private Task OnActorCorrection(ActorCorrection payload, Action onCompleteCallback)
+        private void OnActorCorrection(ActorCorrection payload, Action onCompleteCallback)
         {
             ProcessActorCommand(payload.Actor.Id, payload, onCompleteCallback);
-            return Task.CompletedTask;
         }
 
         [CommandHandler(typeof(ActorUpdate))]

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
-
 using MixedRealityExtension.Animation;
 using MixedRealityExtension.Messaging.Events.Types;
 using MixedRealityExtension.Messaging.Payloads;
@@ -25,7 +24,6 @@ namespace MixedRealityExtension.Core.Components
         {
             public bool Enabled;
             public bool IsInternal;
-            public Action OnCompleteCallback;
         }
 
         private Dictionary<string, AnimationData> _animationData = new Dictionary<string, AnimationData>();
@@ -73,12 +71,6 @@ namespace MixedRealityExtension.Core.Components
                                     animationSpeed: null,
                                     animationEnabled: animationData.Enabled);
 
-                                // If this animation was disabled and we have an OnCompleteCallback set, call it now.
-                                if (!animationData.Enabled && animationData.OnCompleteCallback != null)
-                                {
-                                    animationData.OnCompleteCallback();
-                                }
-
                                 // If this was an internal one-shot animation (aka an interpolation), remove it.
                                 if (!animationData.Enabled && animationData.IsInternal)
                                 {
@@ -99,8 +91,7 @@ namespace MixedRealityExtension.Core.Components
             MWAnimationWrapMode wrapMode,
             MWSetAnimationStateOptions initialState,
             bool isInternal,
-            Action onCreatedCallback,
-            Action onCompleteCallback)
+            Action onCreatedCallback)
         {
             var continuation = new MWContinuation(AttachedActor, null, (result) =>
             {
@@ -200,8 +191,7 @@ namespace MixedRealityExtension.Core.Components
 
                 _animationData[animationName] = new AnimationData()
                 {
-                    IsInternal = isInternal,
-                    OnCompleteCallback = onCompleteCallback
+                    IsInternal = isInternal
                 };
 
                 float initialTime = 0f;
@@ -231,8 +221,7 @@ namespace MixedRealityExtension.Core.Components
             string animationName,
             float duration,
             float[] curve,
-            bool enabled,
-            Action onCompleteCallback)
+            bool enabled)
         {
             // Ensure duration is in range [0...n].
             duration = Math.Max(0, duration);
@@ -327,8 +316,7 @@ namespace MixedRealityExtension.Core.Components
                 wrapMode: MWAnimationWrapMode.Once,
                 initialState: new MWSetAnimationStateOptions { Enabled = enabled },
                 isInternal: true,
-                onCreatedCallback: null,
-                onCompleteCallback);
+                onCreatedCallback: null);
 
             bool LerpFloat(out float dest, float start, float? end, float t)
             {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -38,6 +38,17 @@ namespace MixedRealityExtension.Core
             _unpausedSoundInstances.Add(id);
         }
 
+        public void RemoveSoundInstancesForActor(GameObject gameObject)
+        {
+            foreach (KeyValuePair<Guid, AudioSource> soundInstance in _soundInstances)
+            {
+                if (soundInstance.Value.gameObject == gameObject)
+                {
+                    DestroySoundInstance(soundInstance.Value, soundInstance.Key);
+                }
+            }
+        }
+
         public void ApplySoundStateOptions(AudioSource soundInstance, SoundStateOptions options, Guid id)
         {
             if (options != null)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -105,8 +105,7 @@ namespace MixedRealityExtension.Core
             else
             {
                 var id = _unpausedSoundInstances[_soundStoppedCheckIndex];
-                AudioSource soundInstance;
-                if (_soundInstances.TryGetValue(id, out soundInstance) && !soundInstance.isPlaying)
+                if (_soundInstances.TryGetValue(id, out AudioSource soundInstance) && !soundInstance.isPlaying)
                 {
                     DestroySoundInstance(soundInstance, id);
                 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using MixedRealityExtension.App;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MixedRealityExtension.Core
+{
+    internal class SoundManager
+    {
+        #region Constructor
+
+        public SoundManager(MixedRealityExtensionApp app)
+        {
+            _app = app;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void AddSoundInstance(Guid id, AudioSource soundInstance)
+        {
+            _soundInstances.Add(id, soundInstance);
+        }
+
+        public bool TryGetSoundInstance(Guid id, out AudioSource soundInstance)
+        {
+            return _soundInstances.TryGetValue(id, out soundInstance);
+        }
+
+        public void TrackUnpauseSound(Guid id)
+        {
+            _unpausedSoundInstances.Add(id);
+        }
+
+        public void ApplySoundStateOptions(AudioSource soundInstance, SoundStateOptions options, Guid id)
+        {
+            if (options != null)
+            {
+                //pause must happen before other sound state changes
+                if (options.paused != null && options.paused.Value == true)
+                {
+                    var index = _unpausedSoundInstances.FindIndex(x => x == id);
+                    if (index >= 0)
+                    {
+                        _unpausedSoundInstances.RemoveAt(index);
+                        soundInstance.Pause();
+                    }
+                }
+
+                if (options.Volume != null)
+                {
+                    soundInstance.volume = options.Volume.Value;
+                }
+                if (options.Pitch != null)
+                {
+                    //convert from halftone offset (-12/0/12/24/36) to pitch multiplier (0.5/1/2/4/8).
+                    soundInstance.pitch = Mathf.Pow(2.0f, (options.Pitch.Value / 12.0f));
+                }
+                if (options.Looping != null)
+                {
+                    soundInstance.loop = options.Looping.Value;
+                }
+                if (options.Doppler != null)
+                {
+                    soundInstance.dopplerLevel = options.Doppler.Value;
+                }
+                if (options.MultiChannelSpread != null)
+                {
+                    soundInstance.spread = options.MultiChannelSpread.Value * 180.0f;
+                }
+                if (options.RolloffStartDistance != null)
+                {
+                    soundInstance.minDistance = options.RolloffStartDistance.Value;
+                    soundInstance.maxDistance = options.RolloffStartDistance.Value * 1000000.0f;
+                }
+
+                //unpause must happen after other sound state changes
+                if (options.paused != null && options.paused.Value == false)
+                {
+                    var index = _unpausedSoundInstances.FindIndex(x => x == id);
+                    if (index < 0)
+                    {
+                        soundInstance.UnPause();
+                        _unpausedSoundInstances.Add(id);
+                    }
+                }
+
+
+            }
+        }
+
+        public void Update()
+        {
+            //garbage collect expired sounds, one per frame
+            if (_soundStoppedCheckIndex >= _unpausedSoundInstances.Count)
+            {
+                _soundStoppedCheckIndex = 0;
+            }
+            else
+            {
+                var id = _unpausedSoundInstances[_soundStoppedCheckIndex];
+                AudioSource soundInstance;
+                if (_soundInstances.TryGetValue(id, out soundInstance) && !soundInstance.isPlaying)
+                {
+                    DestroySoundInstance(soundInstance, id);
+                }
+                else
+                {
+                    _soundStoppedCheckIndex++;
+                }
+            }
+        }
+
+        #endregion
+
+        public void DestroySoundInstance(AudioSource soundInstance, Guid id)
+        {
+            Component.Destroy(soundInstance);
+            _soundInstances.Remove(id);
+            var index = _unpausedSoundInstances.FindIndex(x => x == id);
+            if (index >= 0)
+            {
+                _unpausedSoundInstances.RemoveAt(index);
+            }
+        }
+
+        #region Private Fields
+
+        MixedRealityExtensionApp _app;
+        private static Dictionary<Guid, AudioSource> _soundInstances = new Dictionary<Guid, AudioSource>();
+        private static List<Guid> _unpausedSoundInstances = new List<Guid>();
+        private int _soundStoppedCheckIndex = 0;
+
+        #endregion
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -88,12 +88,14 @@
     <Compile Include="Assets\AssetCache.cs" />
     <Compile Include="Assets\AssetGroup.cs" />
     <Compile Include="Assets\AssetSource.cs" />
+    <Compile Include="Core\ActorCommandQueue.cs" />
     <Compile Include="Core\Attachment.cs" />
     <Compile Include="Core\Components\MREAttachmentComponent.cs" />
     <Compile Include="Core\ColliderGeometry.cs" />
     <Compile Include="Core\Interfaces\ICollider.cs" />
     <Compile Include="Core\Interfaces\IUserInfo.cs" />
     <Compile Include="Core\SoundCommand.cs" />
+    <Compile Include="Core\SoundManager.cs" />
     <Compile Include="Core\SoundStateOptions.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/Command.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/Command.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System;
 using System.Reflection;
 
 namespace MixedRealityExtension.Messaging.Commands
@@ -7,17 +8,19 @@ namespace MixedRealityExtension.Messaging.Commands
     internal class Command<T> : ICommand where T : ICommandPayload
     {
         private readonly T _commandPayload;
+        private Action _onCompleteCallback;
 
-        public Command(T commandPayload)
+        public Command(T commandPayload, Action onCompleteCallback)
         {
             _commandPayload = commandPayload;
+            _onCompleteCallback = onCompleteCallback;
         }
 
         public void Execute(ICommandHandlerContext handlerContext, MethodInfo handlerMethod)
         {
             if (handlerMethod != null)
             {
-                handlerMethod.Invoke(handlerContext, new object[] { _commandPayload });
+                handlerMethod.Invoke(handlerContext, new object[] { _commandPayload, _onCompleteCallback });
             }
         }
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/CommandManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/CommandManager.cs
@@ -10,36 +10,169 @@ namespace MixedRealityExtension.Messaging.Commands
 {
     internal class CommandManager : ICommandManager
     {
-        private Dictionary<Type, MethodInfo> _methodHandlers;
-
-        public CommandManager(Type[] commandHandlers)
+        /// <summary>
+        /// Ensures a command handler's onCompleteCallback is called exactly once and in a timely manner.
+        /// </summary>
+        private class PendingCompletionCallback
         {
-            // Build table of handler to method info.
-            //var methods = commandHandlers[0].GetMethods(BindingFlags.NonPublic | BindingFlags.Instance); //commandHandlers.SelectMany(t => t.GetMethods(BindingFlags.NonPublic));
-            //var handlerMethods1 = methods.Where(m => m.GetCustomAttributes().OfType<CommandHandler>().Any());
-            //_methodHandlers = handlerMethods1.ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType);
-
-            _methodHandlers = commandHandlers
-                .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
-                .Where(m => m.GetCustomAttributes().OfType<CommandHandler>().Any())
-                .ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType);
+            public bool Invoked;
+            public string Location;
+            public DateTime CreationTime;
         }
 
-        public void ExecuteCommandPayload(ICommandHandlerContext handlerContext, ICommandPayload commandPayload)
+        // Command handler methods mapped to MethodInfo by handler object type.
+        private readonly Dictionary<Type, Dictionary<Type, MethodInfo>> _methodHandlersByType = new Dictionary<Type, Dictionary<Type, MethodInfo>>();
+        // Registered invocation targets.
+        private readonly Dictionary<Type, ICommandHandlerContext> _invocationTargets = new Dictionary<Type, ICommandHandlerContext>();
+        // The list of running commands that haven't yet invoked their onCompleteCallback handler.
+        private readonly List<PendingCompletionCallback> _pendingCompletionCallbacks = new List<PendingCompletionCallback>();
+        // The next time to check the _pendingCompletionCallbacks queue for timed out commands.
+        // These commands may have a logic error and are not calling their supplied onCompleteCallback.
+        private DateTime _nextQueueCheckTime;
+
+        // The maximum amount of time to wait for an onCompleteCallback to be invoked.
+        private static readonly TimeSpan QueuedCompletionCallbackTimeout = TimeSpan.FromSeconds(60);
+
+        public CommandManager(Dictionary<Type, ICommandHandlerContext> commandHandlers)
+        {
+            foreach (var commandHandlerPair in commandHandlers)
+            {
+                // Build table of handler to method info.
+                //var methods = commandHandlers[0].GetMethods(BindingFlags.NonPublic | BindingFlags.Instance); //commandHandlers.SelectMany(t => t.GetMethods(BindingFlags.NonPublic));
+                //var handlerMethods1 = methods.Where(m => m.GetCustomAttributes().OfType<CommandHandler>().Any());
+                //_methodHandlers = handlerMethods1.ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType);
+
+                _methodHandlersByType.Add(commandHandlerPair.Key, new List<Type>() { commandHandlerPair.Key }
+                    .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
+                    .Where(m => m.GetCustomAttributes().OfType<CommandHandler>().Any())
+                    .ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType));
+
+                _invocationTargets.Add(commandHandlerPair.Key, commandHandlerPair.Value);
+            }
+        }
+
+        public void ExecuteCommandPayload(ICommandPayload commandPayload, Action onCompleteCallback)
         {
             var commandPayloadType = commandPayload.GetType();
-            if (_methodHandlers.ContainsKey(commandPayloadType))
+            foreach (var methodHandlersPair in _methodHandlersByType)
             {
-                var commandType = typeof(Command<>);
-                Type[] typeArgs = { commandPayloadType };
-                commandType = commandType.MakeGenericType(typeArgs);
-                var command = (ICommand)Activator.CreateInstance(commandType, new object[] { commandPayload });
-                command.Execute(handlerContext, _methodHandlers[commandPayloadType]);
+                if (!methodHandlersPair.Value.ContainsKey(commandPayloadType))
+                    continue;
+                if (!_invocationTargets.TryGetValue(methodHandlersPair.Key, out ICommandHandlerContext handlerContext) || handlerContext == null)
+                    continue;
+                ExecuteCommandPayload(handlerContext, commandPayload, methodHandlersPair.Value[commandPayloadType], onCompleteCallback);
+                return;
+            }
+            throw new Exception($"No command handler for command payload: {commandPayloadType.Name}.");
+        }
+
+        public void ExecuteCommandPayload(ICommandHandlerContext handlerContext, ICommandPayload commandPayload, Action onCompleteCallback)
+        {
+            var handlerContextType = handlerContext.GetType();
+            if (_methodHandlersByType.TryGetValue(handlerContextType, out Dictionary<Type, MethodInfo> methodHandlers))
+            {
+                var commandPayloadType = commandPayload.GetType();
+                if (methodHandlers.ContainsKey(commandPayloadType))
+                {
+                    ExecuteCommandPayload(handlerContext, commandPayload, methodHandlers[commandPayloadType], onCompleteCallback);
+                }
+                else
+                {
+                    throw new Exception($"No command handler for command payload: {commandPayloadType.Name} on type: {handlerContextType.Name}");
+                }
             }
             else
             {
-                MREAPI.Logger.LogError($"No command handler registered for command payload: {commandPayloadType.Name}");
+                throw new Exception($"No command handlers registered for type: {handlerContextType.Name}");
             }
+        }
+
+        private void ExecuteCommandPayload(ICommandHandlerContext handlerContext, ICommandPayload commandPayload, MethodInfo methodHandler, Action onCompleteCallback)
+        {
+            var handlerContextType = handlerContext.GetType();
+            var commandPayloadType = commandPayload.GetType();
+            var commandType = typeof(Command<>);
+            Type[] typeArgs = { commandPayloadType };
+            commandType = commandType.MakeGenericType(typeArgs);
+            var command = (ICommand)Activator.CreateInstance(
+                commandType,
+                new object[] {
+                            commandPayload,
+                            CreateQueuedCompletionCallback(
+                                $"{handlerContextType.Name}.{methodHandler.Name}",
+                                onCompleteCallback
+                            ) });
+            command.Execute(handlerContext, methodHandler);
+        }
+
+        public void Update()
+        {
+            // Periodically check for timed out completion callback invocations.
+            if (_pendingCompletionCallbacks.Count > 0)
+            {
+                var currTime = DateTime.Now;
+                if (_nextQueueCheckTime <= currTime)
+                {
+                    while (_pendingCompletionCallbacks.Count > 0)
+                    {
+                        // Callbacks are naturally sorted by creation time.
+                        var callback = _pendingCompletionCallbacks.First();
+                        if (callback.CreationTime <= currTime + QueuedCompletionCallbackTimeout)
+                        {
+                            // Command handler did not invoke its onCompleteCallback in a timely manner.
+                            MREAPI.Logger.LogError($"ERROR: Timeout waiting for onCompleteCallback invocation from {callback.Location}");
+                            _pendingCompletionCallbacks.Remove(callback);
+                            // PONDER: Should we forceably invoke the callback from here?
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    // If there are still items in the list, schedule a time to check it again in the near future.
+                    if (_pendingCompletionCallbacks.Count > 0)
+                    {
+                        _nextQueueCheckTime = currTime + TimeSpan.FromSeconds(5);
+                    }
+                }
+            }
+        }
+
+        private Action CreateQueuedCompletionCallback(string location, Action onCompleteCallback)
+        {
+            if (onCompleteCallback == null) return null;
+
+            // If the queue was previously empty then schedule a time to check it later.
+            if (_pendingCompletionCallbacks.Count == 0)
+            {
+                _nextQueueCheckTime = DateTime.Now + QueuedCompletionCallbackTimeout + TimeSpan.FromSeconds(1);
+            }
+
+            var callback = new PendingCompletionCallback()
+            {
+                Invoked = false,
+                Location = location,
+                CreationTime = DateTime.Now
+            };
+
+            _pendingCompletionCallbacks.Add(callback);
+
+            return () =>
+            {
+                if (!callback.Invoked)
+                {
+                    // Mark as invoked, remove from queue, and make the actual callback.
+                    callback.Invoked = true;
+                    _pendingCompletionCallbacks.Remove(callback);
+                    try { onCompleteCallback?.Invoke(); } catch { }
+                }
+                else
+                {
+                    // If the callback is called multiple times that's an error.
+                    MREAPI.Logger.LogError($"ERROR: onCompleteCallback invoked more than once from {callback.Location}.");
+                }
+            };
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/CommandManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/CommandManager.cs
@@ -123,7 +123,9 @@ namespace MixedRealityExtension.Messaging.Commands
                             // Command handler did not invoke its onCompleteCallback in a timely manner.
                             MREAPI.Logger.LogError($"ERROR: Timeout waiting for onCompleteCallback invocation from {callback.Location}");
                             _pendingCompletionCallbacks.Remove(callback);
-                            // PONDER: Should we forceably invoke the callback from here?
+
+                            // TODO: Report this error up to the app, once we have implemented error logging payloads.
+                            // Task: https://github.com/Microsoft/mixed-reality-extension-sdk/issues/24
                         }
                         else
                         {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/ICommandManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Commands/ICommandManager.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System;
+
 namespace MixedRealityExtension.Messaging.Commands
 {
     internal interface ICommandManager
     {
-        void ExecuteCommandPayload(ICommandHandlerContext handlerContext, ICommandPayload commandPayload);
+        void ExecuteCommandPayload(ICommandHandlerContext handlerContext, ICommandPayload commandPayload, Action onCompleteCallback);
     }
 }


### PR DESCRIPTION
The client can now handle messages for `Actor`s that haven't been created yet. It does this by creating a message queue for every actor and accumulating messages there. Once the actor is created, it will dispatch the messages in serial to the actor. All actor messaging goes through this mechanism now. This means that messages are processed serially per actor. This is a new constraint, but I think it will be acceptable since we have so few async actor messages, mainly create-animation.

One architectural change is that every message handler takes an onCompleteCallback parameter. Message handlers must call this exactly once and within one minute of the message being dispatched. There is new code in `CommandManager` to enforce this.

These changes are pretty extensive. Apologies for the burden.