### PR TITLE
Added a null check. Removed unnecessary template parameter

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/BehaviorComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/BehaviorComponent.cs
@@ -20,8 +20,11 @@ namespace MixedRealityExtension.Core.Components
 
         internal void ClearBehaviorHandler()
         {
-            _behaviorHandler.CleanUp();
-            _behaviorHandler = null;
+            if (_behaviorHandler != null)
+            {
+                _behaviorHandler.CleanUp();
+                _behaviorHandler = null;
+            }
         }
 
         internal bool ContainsBehaviorHandler()

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
@@ -8,16 +8,16 @@ namespace MixedRealityExtension.Util.Unity
 
     public static class AssetFetcher<T> where T : class
     {
-        public struct FetchResult<TT> where TT : T
+        public struct FetchResult
         {
-            public TT Asset;
+            public T Asset;
             public string FailureMessage;
             public bool IsPopulated => Asset != null || FailureMessage != null;
         }
 
-        public static async Task<FetchResult<T>> LoadTask(MonoBehaviour runner, Uri uri)
+        public static async Task<FetchResult> LoadTask(MonoBehaviour runner, Uri uri)
         {
-            FetchResult<T> result = new FetchResult<T>()
+            FetchResult result = new FetchResult()
             {
                 Asset = null,
                 FailureMessage = null


### PR DESCRIPTION
* Missing null check in BehaviorComponent was causing a null ref exception upon actor destroy if a call to actor.setBehavior(null) had been made previously.
* Removed a redundant template parameter from AssetFetcher.
