### PR TITLE
Add extra apps to functional-test scene for sync testing

### DIFF
--- a/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/FunctionalTest-localhost.unity
@@ -432,6 +432,11 @@ Prefab:
       propertyPath: m_WalkSpeed
       value: 20
       objectReference: {fileID: 0}
+    - target: {fileID: 224157667028544564, guid: d67a625648c6fd743a7451d9b6d5357a,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d67a625648c6fd743a7451d9b6d5357a, type: 2}
   m_IsPrefabParent: 0
@@ -860,13 +865,16 @@ MonoBehaviour:
   - gltf-gen-test
   - input-test
   - interpolation-test
-  - library-test
+  - light-test
   - look-at-test
+  - physics-sim-test
   - primitives-test
   - reparent-test
   - rigid-body-test
+  - sound-test
   - text-test
   - user-test
+  - visibility-test
 --- !u!1 &1651315071
 GameObject:
   m_ObjectHideFlags: 0

--- a/MRETestBed/Assets/TestBed Assets/Prefabs/FunctionalTestPad.prefab
+++ b/MRETestBed/Assets/TestBed Assets/Prefabs/FunctionalTestPad.prefab
@@ -54,6 +54,23 @@ GameObject:
   - component: {fileID: 114343749345274750}
   - component: {fileID: 114448795206771884}
   m_Layer: 0
+  m_Name: App (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1552803344752322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4799423963510484}
+  - component: {fileID: 114089863387371726}
+  - component: {fileID: 114375641842334728}
+  m_Layer: 0
   m_Name: App
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91,6 +108,8 @@ GameObject:
   - component: {fileID: 65414399705130274}
   - component: {fileID: 114869768454085058}
   - component: {fileID: 114278254334241760}
+  - component: {fileID: 114011426234863610}
+  - component: {fileID: 114313742553089616}
   m_Layer: 0
   m_Name: TriggerVolume
   m_TagString: Untagged
@@ -109,7 +128,7 @@ Transform:
   m_LocalScale: {x: 12, y: 12, z: 12}
   m_Children: []
   m_Father: {fileID: 4433573494833454}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4183972077742718
 Transform:
@@ -122,7 +141,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4433573494833454}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4408556941943290
 Transform:
@@ -130,13 +149,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1506958488994712}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.1, z: 0}
+  m_LocalRotation: {x: -0.20013751, y: 0, z: 0, w: 0.97976786}
+  m_LocalPosition: {x: 0, y: 4.74, z: 4.92}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4433573494833454}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -23.09, y: 0, z: 0}
 --- !u!4 &4425747817433434
 Transform:
   m_ObjectHideFlags: 1
@@ -148,7 +167,7 @@ Transform:
   m_LocalScale: {x: 10, y: 0.01, z: 10}
   m_Children: []
   m_Father: {fileID: 4433573494833454}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4433573494833454
 Transform:
@@ -160,11 +179,25 @@ Transform:
   m_LocalPosition: {x: 53.498417, y: -7.782287e-19, z: 35.0483}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 4799423963510484}
   - {fileID: 4408556941943290}
   - {fileID: 4425747817433434}
   - {fileID: 4183972077742718}
   - {fileID: 4074845663683980}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4799423963510484
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1552803344752322}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4433573494833454}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &23519333026356252
@@ -331,7 +364,55 @@ TextMesh:
   m_Color:
     serializedVersion: 2
     rgba: 4278560768
+--- !u!114 &114011426234863610
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1851247234395874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b44ae621b51c2474ba8bd950206c39c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LaunchType: 1
+  MREComponent: {fileID: 114343749345274750}
+  StopAppOnExit: 1
+--- !u!114 &114089863387371726
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1552803344752322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c08c6a44e83210c48bc797284376afc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MREURL: 
+  SessionID: 
+  AppID: 
+  AutoStart: 0
+  AutoJoin: 0
+  SceneRoot: {fileID: 0}
+  PlaceholderObject: {fileID: 0}
+  UserGameObject: {fileID: 0}
+  SerifFont: {fileID: 12800000, guid: 70daac12c1ea27648bb12988a837e0a6, type: 3}
+  SansSerifFont: {fileID: 12800000, guid: 7a83a8b8d6810db4aa50e3bde952e2c4, type: 3}
+  DefaultPrimMaterial: {fileID: 2100000, guid: 265cb5b418966a64ea212597d469fa33, type: 2}
 --- !u!114 &114278254334241760
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1851247234395874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba6c758b776a1de45b1c3b91af3ccb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MREComponent: {fileID: 114089863387371726}
+--- !u!114 &114313742553089616
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -365,6 +446,17 @@ MonoBehaviour:
   SerifFont: {fileID: 12800000, guid: 70daac12c1ea27648bb12988a837e0a6, type: 3}
   SansSerifFont: {fileID: 12800000, guid: 7a83a8b8d6810db4aa50e3bde952e2c4, type: 3}
   DefaultPrimMaterial: {fileID: 2100000, guid: 265cb5b418966a64ea212597d469fa33, type: 2}
+--- !u!114 &114375641842334728
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1552803344752322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -40647634, guid: 75e8f482742119848a9b4b20cc1fd6f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114448795206771884
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -388,5 +480,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LaunchType: 1
-  MREComponent: {fileID: 114343749345274750}
-  StopAppOnExit: 0
+  MREComponent: {fileID: 114089863387371726}
+  StopAppOnExit: 1

--- a/MRETestBed/Assets/TestBed Assets/Scripts/InstantiateTests.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/InstantiateTests.cs
@@ -20,8 +20,8 @@ public class InstantiateTests : MonoBehaviour
             var test = GameObject.Instantiate(functionalTestPrefab, transform.parent);
             test.name = testName;
             test.transform.Find("Label").GetComponent<TextMesh>().text = testName;
-            var mre = test.GetComponentInChildren<MREComponent>();
-            if (mre != null)
+            var mres = test.GetComponentsInChildren<MREComponent>();
+            foreach(var mre in mres)
             {
                 mre.SessionID = testName;
                 mre.MREURL = $"{MREURL}?test={testName}&autorun=true";


### PR DESCRIPTION
Each test in the functional test scene now has a second instance of the app with the same session ID, spawned above and behind the first one so you can see them at the same time.