### PR TITLE
[UNITY-RUNTIME]: Grab functionality added to actors

### DIFF
--- a/MRETestBed/Assets/TestBed Assets/Scripts/Behaviors/TargetBehavior.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/Behaviors/TargetBehavior.cs
@@ -9,7 +9,11 @@ namespace Assets.Scripts.Behaviors
 {
     public class TargetBehavior : BehaviorBase, ITargetBehavior
     {
+        public bool Grabbable { get; set; }
+
         public MWAction Target { get; } = new MWAction();
+
+        public MWAction Grab { get; } = new MWAction();
 
         public override Type GetDesiredToolType()
         {

--- a/MRETestBed/Assets/TestBed Assets/Scripts/Tools/ButtonTool.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/Tools/ButtonTool.cs
@@ -19,7 +19,8 @@ namespace Assets.Scripts.Tools
 
             if (Input.GetButtonDown("Fire1"))
             {
-                foreach (var buttonBehavior in Target.GetBehaviors<ButtonBehavior>())
+                var buttonBehavior = Target.GetBehavior<ButtonBehavior>();
+                if (buttonBehavior != null)
                 {
                     var mwUser = buttonBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
@@ -30,7 +31,8 @@ namespace Assets.Scripts.Tools
             }
             else if (Input.GetButtonUp("Fire1"))
             {
-                foreach (var buttonBehavior in Target.GetBehaviors<ButtonBehavior>())
+                var buttonBehavior = Target.GetBehavior<ButtonBehavior>();
+                if (buttonBehavior != null)
                 {
                     var mwUser = buttonBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
@@ -47,13 +49,13 @@ namespace Assets.Scripts.Tools
 
             if (oldTarget != null)
             {
-                var oldBehaviors = oldTarget.GetBehaviors<ButtonBehavior>();
-                foreach (var buttonBehavior in oldBehaviors)
+                var oldBehavior = oldTarget.GetBehavior<ButtonBehavior>();
+                if (oldBehavior != null)
                 {
-                    var mwUser = buttonBehavior.GetMWUnityUser(inputSource.UserGameObject);
+                    var mwUser = oldBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
                     {
-                        buttonBehavior.Hover.StopAction(mwUser);
+                        oldBehavior.Hover.StopAction(mwUser);
                     }
                 }
             }
@@ -61,13 +63,13 @@ namespace Assets.Scripts.Tools
             
             if (newTarget != null)
             {
-                var newBehaviors = newTarget.GetBehaviors<ButtonBehavior>();
-                foreach (var buttonBehavior in newBehaviors)
+                var newBehavior = newTarget.GetBehavior<ButtonBehavior>();
+                if (newBehavior != null)
                 {
-                    var mwUser = buttonBehavior.GetMWUnityUser(inputSource.UserGameObject);
+                    var mwUser = newBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
                     {
-                        buttonBehavior.Hover.StartAction(mwUser);
+                        newBehavior.Hover.StartAction(mwUser);
                     }
                 }
             }

--- a/MRETestBed/Assets/TestBed Assets/Scripts/Tools/GrabTool.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/Tools/GrabTool.cs
@@ -2,42 +2,126 @@
 // Licensed under the MIT License.
 using Assets.Scripts.Behaviors;
 using Assets.Scripts.User;
+using System;
 using UnityEngine;
 
 namespace Assets.Scripts.Tools
 {
-    public class GrabTool : TargetTool
+    public class GrabTool: IDisposable
     {
-        protected override void UpdateTool(InputSource inputSource)
-        {
-            base.UpdateTool(inputSource);
+        private Transform _manipulator;
+        private Transform _previousParent;
+        private Vector3 _manipulatorPosInToolSpace;
+        private Vector3 _manipulatorupInToolSpace;
+        private Vector3 _manipulatorLookAtPosInToolSpace;
+        private InputSource _currentInputSource;
 
-            if (Target == null)
+        public bool GrabActive => CurrentGrabbedTarget != null;
+
+        public GameObject CurrentGrabbedTarget { get; private set; }
+
+        public void Update(InputSource inputSource, GameObject target)
+        {
+            if (target == null)
             {
                 return;
             }
 
             if (Input.GetButtonDown("Fire2"))
             {
-                foreach (var grabBehavior in Target.GetBehaviors<TargetBehavior>())
+                var grabBehavior = target.GetBehavior<TargetBehavior>();
+                if (grabBehavior != null)
                 {
                     var mwUser = grabBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
                     {
-                        //grabBehavior.Grab.StartAction(mwUser);
+                        grabBehavior.Grab.StartAction(mwUser);
                     }
                 }
+
+                StartGrab(inputSource, target);
             }
             else if (Input.GetButtonUp("Fire2"))
             {
-                foreach (var grabBehavior in Target.GetBehaviors<TargetBehavior>())
+                var grabBehavior = target.GetBehavior<TargetBehavior>();
+                if (grabBehavior != null)
                 {
                     var mwUser = grabBehavior.GetMWUnityUser(inputSource.UserGameObject);
                     if (mwUser != null)
                     {
-                        //grabBehavior.Grab.StopAction(mwUser);
+                        grabBehavior.Grab.StopAction(mwUser);
                     }
                 }
+
+                EndGrab();
+            }
+
+            if (GrabActive)
+            {
+                UpdatePosition();
+                UpdateRotation();
+            }
+        }
+
+        private void StartGrab(InputSource inputSource, GameObject target)
+        {
+            if (GrabActive ||target == null)
+            {
+                return;
+            }
+
+            CurrentGrabbedTarget = target;
+            _currentInputSource = inputSource;
+
+            var targetTransform = CurrentGrabbedTarget.transform;
+            var inputTransform = _currentInputSource.transform;
+
+            _manipulator = _manipulator ?? new GameObject("manipulator").transform;
+            _manipulator.parent = null;
+            _manipulator.position = targetTransform.position;
+            _manipulator.rotation = targetTransform.rotation;
+
+            _previousParent = targetTransform.parent;
+            targetTransform.SetParent(_manipulator, worldPositionStays: true);
+
+            _manipulatorPosInToolSpace = inputTransform.InverseTransformPoint(_manipulator.position);
+            _manipulatorupInToolSpace = inputTransform.InverseTransformDirection(_manipulator.up);
+            _manipulatorLookAtPosInToolSpace = inputTransform.InverseTransformPoint(_manipulator.position + _manipulator.forward);
+        }
+
+        private void EndGrab()
+        {
+            if (!GrabActive)
+            {
+                return;
+            }
+
+            CurrentGrabbedTarget.transform.SetParent(_previousParent, worldPositionStays: true);
+            CurrentGrabbedTarget = null;
+
+            _manipulator.localPosition = Vector3.zero;
+            _manipulator.localRotation = Quaternion.identity;
+            _manipulator.localScale = Vector3.one;
+        }
+
+        private void UpdatePosition()
+        {
+            Vector3 targetPosition = _currentInputSource.transform.TransformPoint(_manipulatorPosInToolSpace);
+            _manipulator.position = targetPosition;
+        }
+
+        private void UpdateRotation()
+        {
+            Vector3 targetLookAtPos = _currentInputSource.transform.TransformPoint(_manipulatorLookAtPosInToolSpace);
+            Vector3 targetUp = _currentInputSource.transform.TransformDirection(_manipulatorupInToolSpace);
+            _manipulator.rotation = Quaternion.LookRotation(targetLookAtPos - _manipulator.position, targetUp);
+        }
+
+        public void Dispose()
+        {
+            if (_manipulator != null)
+            {
+                UnityEngine.Object.Destroy(_manipulator.gameObject);
             }
         }
     }

--- a/MRETestBed/Assets/TestBed Assets/Scripts/Tools/ToolUtils.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/Tools/ToolUtils.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using MixedRealityExtension.PluginInterfaces.Behaviors;
-using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Assets.Scripts.Tools
 {
     public static class ToolUtils
     {
-        public static IEnumerable<BehaviorT> GetBehaviors<BehaviorT>(this GameObject _this) 
+        public static BehaviorT GetBehavior<BehaviorT>(this GameObject _this) 
             where BehaviorT : IBehavior
         {
-            return _this.GetComponents<BehaviorT>();
+            return _this.GetComponents<BehaviorT>().FirstOrDefault();
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerBase.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerBase.cs
@@ -27,6 +27,8 @@ namespace MixedRealityExtension.Behaviors
             }
         }
 
+        IBehavior IBehaviorHandler.Behavior => Behavior;
+
         internal BehaviorHandlerBase(
             IBehavior behavior,
             WeakReference<MixedRealityExtensionApp> appRef, 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/Handlers/TargetHandler.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/Handlers/TargetHandler.cs
@@ -10,18 +10,9 @@ namespace MixedRealityExtension.Behaviors.Handlers
 {
     internal class TargetHandler : BehaviorHandlerBase
     {
-        private ITargetBehavior _targetBehavior;
-
-        internal bool Grabbable
-        {
-            get => _targetBehavior.Grabbable;
-            set => _targetBehavior.Grabbable = value;
-        }
-
         internal TargetHandler(ITargetBehavior target, WeakReference<MixedRealityExtensionApp> appRef, IActor attachedActor)
             : base(target, appRef, attachedActor)
         {
-            _targetBehavior = target;
             RegisterActionHandler(target.Target, nameof(target.Target));
             RegisterActionHandler(target.Grab, nameof(target.Grab));
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/Handlers/TargetHandler.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/Handlers/TargetHandler.cs
@@ -10,10 +10,20 @@ namespace MixedRealityExtension.Behaviors.Handlers
 {
     internal class TargetHandler : BehaviorHandlerBase
     {
+        private ITargetBehavior _targetBehavior;
+
+        internal bool Grabbable
+        {
+            get => _targetBehavior.Grabbable;
+            set => _targetBehavior.Grabbable = value;
+        }
+
         internal TargetHandler(ITargetBehavior target, WeakReference<MixedRealityExtensionApp> appRef, IActor attachedActor)
             : base(target, appRef, attachedActor)
         {
+            _targetBehavior = target;
             RegisterActionHandler(target.Target, nameof(target.Target));
+            RegisterActionHandler(target.Grab, nameof(target.Grab));
         }
 
         internal static TargetHandler Create(IActor actor, WeakReference<MixedRealityExtensionApp> appRef)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/IBehaviorHandler.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/IBehaviorHandler.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using MixedRealityExtension.PluginInterfaces.Behaviors;
 using System;
 
 namespace MixedRealityExtension.Behaviors
 {
     internal interface IBehaviorHandler : IEquatable<IBehaviorHandler>
     {
+        IBehavior Behavior { get; }
+
         BehaviorType BehaviorType { get; }
 
         void CleanUp();

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -20,6 +20,7 @@ using UnityEngine;
 
 using UnityLight = UnityEngine.Light;
 using UnityCollider = UnityEngine.Collider;
+using MixedRealityExtension.PluginInterfaces.Behaviors;
 
 namespace MixedRealityExtension.Core
 {
@@ -78,7 +79,9 @@ namespace MixedRealityExtension.Core
         internal MWTransform LocalTransform => transform.ToMWTransform();
 
         internal Guid MaterialId { get; set; } = Guid.Empty;
-
+		
+		internal bool Grabbable { get; private set; }
+		
         private bool AppearanceEnabled = true;
         private bool ActiveAndEnabled => ((Parent as Actor)?.ActiveAndEnabled ?? true) && AppearanceEnabled;
 
@@ -775,6 +778,23 @@ namespace MixedRealityExtension.Core
                     _lookAt = GetOrCreateActorComponent<LookAtComponent>();
                 }
                 _lookAt.ApplyPatch(lookAtPatch);
+            }
+        }
+
+        private void PatchGrabbable(bool? grabbable)
+        {
+            if (grabbable != null && grabbable.Value != Grabbable)
+            {
+                // Update existing behavior or add a basic target behavior if there isn't one already.
+                var behaviorComponent = GetActorComponent<BehaviorComponent>();
+                if (behaviorComponent != null)
+                {
+                    behaviorComponent = GetOrCreateActorComponent<BehaviorComponent>();
+                    var handler = BehaviorHandlerFactory.CreateBehaviorHandler(BehaviorType.Target, this, new WeakReference<MixedRealityExtensionApp>(App));
+                    behaviorComponent.SetBehaviorHandler(handler);
+                }
+
+                ((ITargetBehavior)behaviorComponent.Behavior).Grabbable = grabbable.Value;
             }
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -79,10 +79,11 @@ namespace MixedRealityExtension.Core
         internal MWTransform LocalTransform => transform.ToMWTransform();
 
         internal Guid MaterialId { get; set; } = Guid.Empty;
-		
-		internal bool Grabbable { get; private set; }
-		
-        private bool AppearanceEnabled = true;
+
+        internal bool Grabbable { get; private set; }
+        
+        private bool AppearanceEnabled { get; set; } = true;
+
         private bool ActiveAndEnabled => ((Parent as Actor)?.ActiveAndEnabled ?? true) && AppearanceEnabled;
 
         #endregion
@@ -164,6 +165,7 @@ namespace MixedRealityExtension.Core
             PatchText(actorPatch.Text);
             PatchAttachment(actorPatch.Attachment);
             PatchLookAt(actorPatch.LookAt);
+            PatchGrabbable(actorPatch.Grabbable);
         }
 
         internal void SynchronizeEngine(ActorPatch actorPatch)
@@ -787,7 +789,7 @@ namespace MixedRealityExtension.Core
             {
                 // Update existing behavior or add a basic target behavior if there isn't one already.
                 var behaviorComponent = GetActorComponent<BehaviorComponent>();
-                if (behaviorComponent != null)
+                if (behaviorComponent == null)
                 {
                     behaviorComponent = GetOrCreateActorComponent<BehaviorComponent>();
                     var handler = BehaviorHandlerFactory.CreateBehaviorHandler(BehaviorType.Target, this, new WeakReference<MixedRealityExtensionApp>(App));
@@ -795,6 +797,8 @@ namespace MixedRealityExtension.Core
                 }
 
                 ((ITargetBehavior)behaviorComponent.Behavior).Grabbable = grabbable.Value;
+
+                Grabbable = grabbable.Value;
             }
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/BehaviorComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/BehaviorComponent.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using MixedRealityExtension.Behaviors;
+using MixedRealityExtension.PluginInterfaces.Behaviors;
 
 namespace MixedRealityExtension.Core.Components
 {
     internal class BehaviorComponent : ActorComponentBase
     {
         private IBehaviorHandler _behaviorHandler;
+
+        internal IBehavior Behavior => _behaviorHandler.Behavior;
 
         internal void SetBehaviorHandler(IBehaviorHandler behaviorHandler)
         {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ActorPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/ActorPatch.cs
@@ -30,6 +30,9 @@ namespace MixedRealityExtension.Patching.Types
         [PatchProperty]
         public LookAtPatch LookAt { get; set; }
 
+        [PatchProperty]
+        public bool? Grabbable { get; set; }
+
         public ActorPatch()
         {
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/Behaviors/ITargetBehavior.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/Behaviors/ITargetBehavior.cs
@@ -10,8 +10,18 @@ namespace MixedRealityExtension.PluginInterfaces.Behaviors
     public interface ITargetBehavior : IBehavior
     {
         /// <summary>
-        /// The target action in the target platform..
+        /// Whether the target is grabbable or not.
+        /// </summary>
+        bool Grabbable { get; set; }
+
+        /// <summary>
+        /// The target action in the target platform.
         /// </summary>
         MWAction Target { get; }
+
+        /// <summary>
+        /// The grab action in the target platform.
+        /// </summary>
+        MWAction Grab { get; }
     }
 }


### PR DESCRIPTION
This is the runtime portion of the grab functionality being added to actors. It leverages the behavior system for completing the actual interaction within the host app.  This includes an implementation of grab behavior within the MRETestBed project.

SDK reference: [PR#260](https://github.com/Microsoft/mixed-reality-extension-sdk/pull/260)