### PR TITLE
Rename appearance patch field, convert signed ints to unsigned

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
@@ -19,7 +19,7 @@ namespace MixedRealityExtension
                 NullValueHandling = NullValueHandling.Ignore,
             };
 
-            SerializerSettings.Converters.Add(new Messaging.Payloads.Converters.DashFormattedEnumConverter());
+            SerializerSettings.Converters.Add(new DashFormattedEnumConverter());
             SerializerSettings.Converters.Add(new PayloadConverter());
             SerializerSettings.Converters.Add(new CollisionGeometryConverter());
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -82,8 +82,8 @@ namespace MixedRealityExtension.Core
         
         internal bool Grabbable { get; private set; }
         
-        private UInt32 appearanceEnabled = UInt32.MaxValue;
-        private bool activeAndEnabled =>
+        internal UInt32 appearanceEnabled = UInt32.MaxValue;
+        internal bool activeAndEnabled =>
             ((Parent as Actor)?.activeAndEnabled ?? true)
             && ((App.LocalUser?.Groups ?? 1) & appearanceEnabled) > 0;
 
@@ -654,9 +654,10 @@ namespace MixedRealityExtension.Core
                 return;
             }
 
-            if (appearance.EnabledPacked != null)
+            var enabled = appearance.EnabledPacked ?? appearance.Enabled;
+            if (enabled != null)
             {
-                appearanceEnabled = appearance.EnabledPacked.Value;
+                appearanceEnabled = enabled.Value;
                 ApplyVisibilityUpdate(this);
             }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -220,7 +220,7 @@ namespace MixedRealityExtension.Core
                 Collider = collider,
                 Appearance = new AppearancePatch()
                 {
-                    Enabled = appearanceEnabled,
+                    EnabledPacked = appearanceEnabled,
                     MaterialId = MaterialId
                 }
             };
@@ -654,9 +654,9 @@ namespace MixedRealityExtension.Core
                 return;
             }
 
-            if (appearance.Enabled != null)
+            if (appearance.EnabledPacked != null)
             {
-                appearanceEnabled = appearance.Enabled.Value;
+                appearanceEnabled = appearance.EnabledPacked.Value;
                 ApplyVisibilityUpdate(this);
             }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />
     <Compile Include="Factories\DefaultMaterialPatcher.cs" />
+    <Compile Include="Messaging\Payloads\Converters\UnsignedConverter.cs" />
     <Compile Include="Patching\Types\AppearancePatch.cs" />
     <Compile Include="Patching\Types\LookAtPatch.cs" />
     <Compile Include="PluginInterfaces\IUserInfoProvider.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/UnsignedConverter.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/UnsignedConverter.cs
@@ -16,7 +16,7 @@ namespace MixedRealityExtension.Messaging.Payloads.Converters
         /// <inheritdoc />
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(UInt32);
+            return UtilMethods.GetActualType(objectType) == typeof(UInt32);
         }
 
         /// <inheritdoc />
@@ -31,7 +31,8 @@ namespace MixedRealityExtension.Messaging.Payloads.Converters
             }
             else
             {
-                throw new JsonSerializationException($"Failed to deserialize {reader.Value}");
+                UnityEngine.Debug.Log($"Failed to deserialize {reader.ValueType} {reader.Value}");
+                return null;
             }
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/UnsignedConverter.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/Converters/UnsignedConverter.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Text;
+using MixedRealityExtension.Util;
+using Newtonsoft.Json;
+
+namespace MixedRealityExtension.Messaging.Payloads.Converters
+{
+    /// <summary>
+    /// Converts signed integers into bit-equivalent unsigned integers,
+    /// because JS doesn't have a concept of unsigned.
+    /// </summary>
+    public class UnsignedConverter : JsonConverter
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(UInt32);
+        }
+
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Integer)
+            {
+                Int32 signed = Convert.ToInt32((Int64)reader.Value);
+                byte[] bytes = BitConverter.GetBytes(signed);
+                UInt32 unsigned = BitConverter.ToUInt32(bytes, 0);
+                return unsigned;
+            }
+            else
+            {
+                throw new JsonSerializationException($"Failed to deserialize {reader.Value}");
+            }
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            UInt32 unsigned = (UInt32)value;
+            byte[] bytes = BitConverter.GetBytes(unsigned);
+            Int32 signed = BitConverter.ToInt32(bytes, 0);
+            writer.WriteValue(signed);
+        }
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
@@ -7,7 +7,8 @@ namespace MixedRealityExtension.Patching.Types
     public class AppearancePatch
     {
         [PatchProperty]
-        public UInt32? Enabled { get; set; }
+        [JsonConverter(typeof(UnsignedConverter))]
+        public UInt32? EnabledPacked { get; set; }
 
         [PatchProperty]
         public Guid? MaterialId { get; set; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
@@ -6,6 +6,9 @@ namespace MixedRealityExtension.Patching.Types
 {
     public class AppearancePatch
     {
+        [JsonConverter(typeof(UnsignedConverter))]
+        public UInt32? Enabled { get; set; }
+
         [PatchProperty]
         [JsonConverter(typeof(UnsignedConverter))]
         public UInt32? EnabledPacked { get; set; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/AppearancePatch.cs
@@ -6,6 +6,11 @@ namespace MixedRealityExtension.Patching.Types
 {
     public class AppearancePatch
     {
+        // This field has the same data as EnabledPacked, but it's sent on actor-create
+        // instead of actor-update. This is a consequence of our API initialization struct
+        // (ActorLike) being the network transmission struct as well. Couldn't make a clean
+        // API without making the transmission layer a little uglier. Sorry :(
+        // - Steven, 2019.03.22
         [JsonConverter(typeof(UnsignedConverter))]
         public UInt32? Enabled { get; set; }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Patching/Types/UserPatch.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 using MixedRealityExtension.Core;
 using MixedRealityExtension.Core.Types;
+using MixedRealityExtension.Messaging.Payloads.Converters;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -15,6 +17,7 @@ namespace MixedRealityExtension.Patching.Types
         public string Name { get; set; }
 
         [PatchProperty]
+        [JsonConverter(typeof(UnsignedConverter))]
         public UInt32? Groups { get; set; }
 
         public Dictionary<string, string> Properties { get; set; }


### PR DESCRIPTION
* Change patch field name to match Microsoft/mixed-reality-extension-sdk#272
* Add an unsigned int JSON converter, because JS doesn't know about that concept and sends down serialized signed ints