### PR TITLE
[Unity] Misc synchronization fixes and improvements

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -81,9 +81,9 @@ namespace MixedRealityExtension.Core
         private Attachment _cachedAttachment = new Attachment();
 
         internal Guid MaterialId { get; set; } = Guid.Empty;
-        
+
         internal bool Grabbable { get; private set; }
-        
+
         internal UInt32 appearanceEnabled = UInt32.MaxValue;
         internal bool activeAndEnabled =>
             ((Parent as Actor)?.activeAndEnabled ?? true)
@@ -116,10 +116,12 @@ namespace MixedRealityExtension.Core
             return component;
         }
 
-        internal void SynchronizeApp()
+        internal void SynchronizeApp(ActorComponentType? subscriptionsOverride = null)
         {
             if (CanSync())
             {
+                var subscriptions = subscriptionsOverride.HasValue ? subscriptionsOverride.Value : _subscriptions;
+
                 // Handle changes in game state and raise appropriate events for network updates.
                 var actorPatch = new ActorPatch(Id);
 
@@ -135,12 +137,12 @@ namespace MixedRealityExtension.Core
                     actorPatch.ParentId = ParentId;
                 }
 
-                if (ShouldSync(_subscriptions, ActorComponentType.Transform))
+                if (ShouldSync(subscriptions, ActorComponentType.Transform))
                 {
                     GenerateTransformPatch(actorPatch);
                 }
 
-                if (ShouldSync(_subscriptions, ActorComponentType.Rigidbody))
+                if (ShouldSync(subscriptions, ActorComponentType.Rigidbody))
                 {
                     GenerateRigidBodyPatch(actorPatch);
                 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Attachment.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Attachment.cs
@@ -9,8 +9,8 @@ namespace MixedRealityExtension.Core
 {
     public class Attachment : IEquatable<Attachment>
     {
-        internal string AttachPoint { get; set; }
-        internal Guid UserId { get; set; }
+        internal string AttachPoint { get; set; } = "none";
+        internal Guid UserId { get; set; } = Guid.Empty;
 
         public bool Equals(Attachment other)
         {
@@ -45,7 +45,7 @@ namespace MixedRealityExtension.Core
 
         internal AttachmentPatch GeneratePatch(Attachment other)
         {
-            if (this != other)
+            if (!this.Equals(other))
             {
                 return new AttachmentPatch()
                 {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -30,23 +30,6 @@ namespace MixedRealityExtension.Core.Components
 
         private bool GetAnimationData(string animationName, out AnimationData animationData) => _animationData.TryGetValue(animationName, out animationData);
 
-        internal bool Animating
-        {
-            get
-            {
-                var animation = GetUnityAnimationComponent();
-                if (animation != null)
-                {
-                    if (animation.isPlaying)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-        }
-
         private void Update()
         {
             // Check for changes to an animation's enabled state and notify the server when a change is detected.
@@ -70,6 +53,12 @@ namespace MixedRealityExtension.Core.Components
                                     animationTime: null,
                                     animationSpeed: null,
                                     animationEnabled: animationData.Enabled);
+
+                                // If the animation stopped, sync the actor's final transform.
+                                if (!animationData.Enabled)
+                                {
+                                    AttachedActor.SynchronizeApp(ActorComponentType.Transform);
+                                }
 
                                 // If this was an internal one-shot animation (aka an interpolation), remove it.
                                 if (!animationData.Enabled && animationData.IsInternal)

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IEngineConstants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IEngineConstants.cs
@@ -4,9 +4,9 @@ namespace MixedRealityExtension.PluginInterfaces
 {
     public struct MRELayers
     {
-        int Object;
-        int Environment;
-        int Hologram;
+        // int Object;
+        // int Environment;
+        // int Hologram;
     }
 
     public interface IEngineConstants


### PR DESCRIPTION
- Attachment component was falsely generating a patch when no changes were made.
- When an animation stops, sync the actor's final transform.