### PR TITLE
Fix for #254: Actor.animateTo() causes client crash on zero duration

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Components/AnimationComponent.cs
@@ -281,13 +281,16 @@ namespace MixedRealityExtension.Core.Components
 
             // Generate keyframes
             float currTime = 0;
-            while (currTime <= duration)
+
+            do
             {
                 var keyframe = NewKeyframe(currTime);
-                BuildKeyframe(keyframe, currTime / duration);
+                var unitTime = duration > 0 ? currTime / duration : 1;
+                BuildKeyframe(keyframe, unitTime);
                 keyframes.Add(keyframe);
                 currTime += timeStep;
             }
+            while (currTime <= duration && timeStep > 0);
 
             // Final frame (if needed)
             if (currTime - duration > 0)


### PR DESCRIPTION
Fixes https://github.com/Microsoft/mixed-reality-extension-sdk/issues/254