### PR TITLE
Refactor usage of MixedRealityExtensionApp; fix build path error with spaces

### DIFF
--- a/buildMREUnityRuntimeDLL.bat
+++ b/buildMREUnityRuntimeDLL.bat
@@ -1,7 +1,7 @@
 @rem Bootstrapping script to build MREUnityRuntimeLib dll
 @echo off
 
-for /f "usebackq tokens=*" %%i in (`%~dp0tools\vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`"%~dp0tools\vswhere" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
   set VSInstallDir=%%i
 )
 
@@ -13,7 +13,7 @@ if not exist "%VSInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
 
 echo Building Mixed Reality Unity Runtime DLL
 set ErrorString=Failed Visual Studio build
-"%VSInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" %~dp0MREUnityRuntime\MREUnityRuntime.sln /p:Configuration=Release /p:Platform="Any CPU"
+"%VSInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" "%~dp0MREUnityRuntime\MREUnityRuntime.sln" /p:Configuration=Release /p:Platform="Any CPU"
 
 if errorlevel 1 (
   echo BUILD FAILED: %ErrorString%


### PR DESCRIPTION
This change only refactors, no change to functionality. 
Removed IConnectionInternal that is not used.
Made several classes public: this will help integrating the part that handles the connection into another 3D engine potentially.
Replaced MixedRealityExtensionApp with its interface, where possible.