### PR TITLE
DO NOT MERGE: Video Player Factory interface abstraction

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -42,6 +42,7 @@ namespace MixedRealityExtension.API
             IAssetCache assetCache = null,
             IGLTFImporterFactory gltfImporterFactory = null,
             IMaterialPatcher materialPatcher = null,
+            IVideoPlayerFactory videoPlayerFactory = null,
             IUserInfoProvider userInfoProvider = null,
 			IEngineConstants engineConstants = null,
             IMRELogger logger = null)
@@ -51,6 +52,7 @@ namespace MixedRealityExtension.API
             AppsAPI.TextFactory = textFactory ?? throw new ArgumentException($"{nameof(textFactory)} cannot be null");
             AppsAPI.PrimitiveFactory = primitiveFactory ?? new MWPrimitiveFactory();
             AppsAPI.LibraryResourceFactory = libraryFactory;
+            AppsAPI.VideoPlayerFactory = videoPlayerFactory;
             AppsAPI.AssetCache = assetCache ?? new AssetCache();
             AppsAPI.GLTFImporterFactory = gltfImporterFactory ?? new GLTFImporterFactory();
             AppsAPI.MaterialPatcher = materialPatcher ?? new DefaultMaterialPatcher();
@@ -102,6 +104,8 @@ namespace MixedRealityExtension.API
         internal IPrimitiveFactory PrimitiveFactory { get; set; }
 
         internal ILibraryResourceFactory LibraryResourceFactory { get; set; }
+
+        internal IVideoPlayerFactory VideoPlayerFactory { get; set; }
 
         internal IGLTFImporterFactory GLTFImporterFactory { get; set; }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/Definitions.cs
@@ -47,6 +47,11 @@ namespace MixedRealityExtension.Assets
         /// If this asset is a sound, contains those properties
         /// </summary>
         public Sound? Sound;
+
+        /// <summary>
+        /// If this asset is a video, contains those properties
+        /// </summary>
+        public VideoStream? VideoStream;
     }
 
     /// <summary>
@@ -98,8 +103,31 @@ namespace MixedRealityExtension.Assets
     }
 
     /// <summary>
-    /// Contains material asset info
+    /// Type  describing how to interpret the video Source URI
     /// </summary>
+    public enum VideoSourceType
+    {
+        /// <summary>
+        ///  URI is just a Raw URL
+        /// </summary>
+        Raw,
+        /// <summary>
+        ///  URI is Mixer.com stream
+        /// </summary>
+        Mixer,
+        /// <summary>
+        ///  URI is Twitch stream
+        /// </summary>
+        Twitch,
+        /// <summary>
+        ///  URI is a YouTube video or live stream
+        /// </summary>
+        YouTube,
+    }
+
+    /// <summary>
+         /// Contains material asset info
+         /// </summary>
     public struct Material
     {
         /// <summary>
@@ -172,6 +200,27 @@ namespace MixedRealityExtension.Assets
         /// <summary>
         /// Duration in seconds.
         /// </summary>
-        public float Duration;
+        public float? Duration;
+    }
+
+    /// <summary>
+    /// Contains a basic video stream description
+    /// </summary>
+    public struct VideoStream
+    {
+        /// <summary>
+        /// The type describing the URI. use as URL if empty
+        /// </summary>
+        public VideoSourceType? VideoSourceType;
+
+        /// <summary>
+        /// The VideoSourceType specific URI
+        /// </summary>
+        public string Uri;
+
+        /// <summary>
+        /// Duration in seconds.
+        /// </summary>
+        public float? Duration;
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -1238,7 +1238,7 @@ namespace MixedRealityExtension.Core
         [CommandHandler(typeof(SetMediaState))]
         private void OnSetMediaState(SetMediaState payload, Action onCompleteCallback)
         {
-            if (payload.SoundCommand == SoundCommand.Start)
+            if (payload.MediaCommand == MediaCommand.Start)
             {
                 if (_mediaInstances == null)
                 {
@@ -1267,13 +1267,13 @@ namespace MixedRealityExtension.Core
             {
                 if (_mediaInstances != null && _mediaInstances.TryGetValue(payload.Id, out System.Object mediaInstance))
                 {
-                    switch (payload.SoundCommand)
+                    switch (payload.MediaCommand)
                     {
-                        case SoundCommand.Stop:
+                        case MediaCommand.Stop:
                             _mediaInstances.Remove(payload.Id);
                             DestroyMediaById(payload.Id, mediaInstance);
                             break;
-                        case SoundCommand.Update:
+                        case MediaCommand.Update:
                             if (mediaInstance is AudioSource soundInstance)
                             {
                                 App.SoundManager.ApplyMediaStateOptions(this, soundInstance, payload.Options, payload.Id, false);

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -1260,9 +1260,7 @@ namespace MixedRealityExtension.Core
                     {
                         videoPlayer.Play(videoStreamDescription, payload.Options, payload.StartTimeOffset);
                     }
-//                    videoPlayer.Play("https://www.youtube.com/watch?v=E6GAxUVs37c", payload.Options, payload.StartTimeOffset);
                     _mediaInstances.Add(payload.Id, videoPlayer);
-
                 }
             }
             else
@@ -1275,7 +1273,6 @@ namespace MixedRealityExtension.Core
                             _mediaInstances.Remove(payload.Id);
                             DestroyMediaById(payload.Id, mediaInstance);
                             break;
-
                         case SoundCommand.Update:
                             if (mediaInstance is AudioSource soundInstance)
                             {
@@ -1284,13 +1281,10 @@ namespace MixedRealityExtension.Core
                             else if (mediaInstance is IVideoPlayer videoPlayer)
                             {
                                 videoPlayer.ApplyMediaStateOptions(payload.Options);
-
                             }
                             break;
                     }
-
                 }
-
             }
             onCompleteCallback?.Invoke();
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -121,7 +121,7 @@ namespace MixedRealityExtension.Core
         private Attachment _cachedAttachment = new Attachment();
 
         internal Guid MaterialId { get; set; } = Guid.Empty;
-        
+
         internal bool Grabbable { get; private set; }
 
         internal bool IsGrabbed
@@ -137,7 +137,7 @@ namespace MixedRealityExtension.Core
                 return false;
             }
         }
-        
+
         internal UInt32 appearanceEnabled = UInt32.MaxValue;
         internal bool activeAndEnabled =>
             ((Parent as Actor)?.activeAndEnabled ?? true)
@@ -807,7 +807,7 @@ namespace MixedRealityExtension.Core
                 }
                 else
                 {
-                    PatchTransformWithRigidBody(transformPatch);   
+                    PatchTransformWithRigidBody(transformPatch);
                 }
             }
         }
@@ -1235,8 +1235,8 @@ namespace MixedRealityExtension.Core
             onCompleteCallback?.Invoke();
         }
 
-        [CommandHandler(typeof(SetSoundState))]
-        private void OnSetSoundState(SetSoundState payload, Action onCompleteCallback)
+        [CommandHandler(typeof(SetMediaState))]
+        private void OnSetMediaState(SetMediaState payload, Action onCompleteCallback)
         {
             if (payload.SoundCommand == SoundCommand.Start)
             {
@@ -1255,7 +1255,7 @@ namespace MixedRealityExtension.Core
                         ?? throw new ArgumentException("Cannot movie player not implemented library.");
                     IVideoPlayer videoPlayer = factory.CreateVideoPlayer(this);
 
-                    var videoStreamDescription= MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as VideoStreamDescription;
+                    var videoStreamDescription = MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as VideoStreamDescription;
                     if (videoStreamDescription != null)
                     {
                         videoPlayer.Play(videoStreamDescription, payload.Options, payload.StartTimeOffset);
@@ -1276,7 +1276,7 @@ namespace MixedRealityExtension.Core
                         case SoundCommand.Update:
                             if (mediaInstance is AudioSource soundInstance)
                             {
-                                App.SoundManager.ApplySoundStateOptions(this, soundInstance, payload.Options, payload.Id, false);
+                                App.SoundManager.ApplyMediaStateOptions(this, soundInstance, payload.Options, payload.Id, false);
                             }
                             else if (mediaInstance is IVideoPlayer videoPlayer)
                             {
@@ -1311,6 +1311,10 @@ namespace MixedRealityExtension.Core
             if (mediaInstance is AudioSource soundInstance)
             {
                 App.SoundManager.DestroySoundInstance(soundInstance, id);
+            }
+            else if (mediaInstance is IVideoPlayer videoPlayer)
+            {
+                videoPlayer.Destroy();
             }
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -22,7 +22,7 @@ using UnityLight = UnityEngine.Light;
 using UnityCollider = UnityEngine.Collider;
 using MixedRealityExtension.PluginInterfaces.Behaviors;
 using MixedRealityExtension.Util;
-
+using IVideoPlayer = MixedRealityExtension.PluginInterfaces.IVideoPlayer;
 namespace MixedRealityExtension.Core
 {
     /// <summary>
@@ -34,7 +34,7 @@ namespace MixedRealityExtension.Core
         private UnityLight _light;
         private UnityCollider _collider;
         private LookAtComponent _lookAt;
-        private Dictionary<Guid, AudioSource> _soundInstances;
+        private Dictionary<Guid, System.Object> _mediaInstances;
         private float _nextUpdateTime;
         private bool _grabbedLastSync = false;
 
@@ -444,11 +444,11 @@ namespace MixedRealityExtension.Core
                 userInfo.BeforeAvatarDestroyed -= UserInfo_BeforeAvatarDestroyed;
             }
 
-            if (_soundInstances != null)
+            if (_mediaInstances != null)
             {
-                foreach (KeyValuePair<Guid, AudioSource> soundInstance in _soundInstances)
+                foreach (KeyValuePair<Guid, System.Object> mediaInstance in _mediaInstances)
                 {
-                    App.SoundManager.DestroySoundInstance(soundInstance.Value, soundInstance.Key);
+                    DestroyMediaById(mediaInstance.Key, mediaInstance.Value);
                 }
             }
         }
@@ -1240,51 +1240,84 @@ namespace MixedRealityExtension.Core
         {
             if (payload.SoundCommand == SoundCommand.Start)
             {
+                if (_mediaInstances == null)
+                {
+                    _mediaInstances = new Dictionary<Guid, System.Object>();
+                }
                 AudioSource soundInstance = App.SoundManager.TryAddSoundInstance(this, payload.Id, payload.SoundAssetId, payload.Options, payload.StartTimeOffset);
                 if (soundInstance)
                 {
-                    if (_soundInstances == null)
+                    _mediaInstances.Add(payload.Id, soundInstance);
+                }
+                else
+                {
+                    var factory = MREAPI.AppsAPI.VideoPlayerFactory
+                        ?? throw new ArgumentException("Cannot movie player not implemented library.");
+                    IVideoPlayer videoPlayer = factory.CreateVideoPlayer(this);
+
+                    var videoStreamDescription= MREAPI.AppsAPI.AssetCache.GetAsset(payload.SoundAssetId) as VideoStreamDescription;
+                    if (videoStreamDescription != null)
                     {
-                        _soundInstances = new Dictionary<Guid, AudioSource>();
+                        videoPlayer.Play(videoStreamDescription, payload.Options, payload.StartTimeOffset);
                     }
-                    _soundInstances.Add(payload.Id, soundInstance);
+//                    videoPlayer.Play("https://www.youtube.com/watch?v=E6GAxUVs37c", payload.Options, payload.StartTimeOffset);
+                    _mediaInstances.Add(payload.Id, videoPlayer);
+
                 }
             }
             else
             {
-                if (_soundInstances != null && _soundInstances.TryGetValue(payload.Id, out AudioSource soundInstance))
+                if (_mediaInstances != null && _mediaInstances.TryGetValue(payload.Id, out System.Object mediaInstance))
                 {
                     switch (payload.SoundCommand)
                     {
                         case SoundCommand.Stop:
-                            DestroySoundById(payload.Id, soundInstance);
+                            _mediaInstances.Remove(payload.Id);
+                            DestroyMediaById(payload.Id, mediaInstance);
                             break;
+
                         case SoundCommand.Update:
-                            App.SoundManager.ApplySoundStateOptions(this, soundInstance, payload.Options, payload.Id, false);
+                            if (mediaInstance is AudioSource soundInstance)
+                            {
+                                App.SoundManager.ApplySoundStateOptions(this, soundInstance, payload.Options, payload.Id, false);
+                            }
+                            else if (mediaInstance is IVideoPlayer videoPlayer)
+                            {
+                                videoPlayer.ApplyMediaStateOptions(payload.Options);
+
+                            }
                             break;
                     }
+
                 }
+
             }
             onCompleteCallback?.Invoke();
         }
 
         public bool CheckIfSoundExpired(Guid id)
         {
-            if (_soundInstances != null && _soundInstances.TryGetValue(id, out AudioSource soundInstance))
+            if (_mediaInstances != null && _mediaInstances.TryGetValue(id, out System.Object mediaInstance))
             {
-                if (soundInstance.isPlaying)
+                if (mediaInstance is AudioSource soundInstance)
                 {
-                    return false;
+                    if (soundInstance.isPlaying)
+                    {
+                        return false;
+                    }
+                    _mediaInstances.Remove(id);
+                    DestroyMediaById(id, soundInstance);
                 }
-                DestroySoundById(id, soundInstance);
             }
             return true;
         }
 
-        private void DestroySoundById(Guid id, AudioSource soundInstance)
+        private void DestroyMediaById(Guid id, object mediaInstance)
         {
-            _soundInstances.Remove(id);
-            App.SoundManager.DestroySoundInstance(soundInstance, id);
+            if (mediaInstance is AudioSource soundInstance)
+            {
+                App.SoundManager.DestroySoundInstance(soundInstance, id);
+            }
         }
 
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -198,8 +198,8 @@ namespace MixedRealityExtension.Core
             ProcessActorCommand(payload.ActorId, payload, onCompleteCallback);
         }
 
-        [CommandHandler(typeof(SetSoundState))]
-        private void OnSetSoundState(SetSoundState payload, Action onCompleteCallback)
+        [CommandHandler(typeof(SetMediaState))]
+        private void OnSetMediaState(SetMediaState payload, Action onCompleteCallback)
         {
             ProcessActorCommand(payload.ActorId, payload, onCompleteCallback);
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaCommand.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaCommand.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension
     /// <summary>
     /// Special commands to change the mode of the sound instance?
     /// </summary>
-    public enum SoundCommand
+    public enum MediaCommand
     {
         /// <summary>
         /// Start a new sound instance

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaStateOptions.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaStateOptions.cs
@@ -18,7 +18,8 @@ namespace MixedRealityExtension
         public float? Volume;
 
         /// <summary>
-        /// repeat the media when ended, or turn it off after playing once. Default to false
+        /// repeat the sound when ended, or turn it off after playing once. Default to false
+        /// This does not apply to video streams, only to sounds
         /// </summary>
         public bool? Looping;
 
@@ -57,7 +58,7 @@ namespace MixedRealityExtension
 
         /// <summary>
         /// Should the video stream be visible or invisible
-        /// Does not apply to sounds, only to video streams
+        /// Does not apply to sounds, only to video streams.
         /// </summary>
         public bool? Visible;
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaStateOptions.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/MediaStateOptions.cs
@@ -3,9 +3,9 @@
 namespace MixedRealityExtension
 {
     /// <summary>
-    /// Modifiable Sound Instance Options
+    /// Modifiable Media Instance Options - shared between sounds and video streams
     /// </summary>
-    public class SoundStateOptions
+    public class MediaStateOptions
     {
         /// <summary>
         /// pitch offset in halftones (0=default, 12=one octave higher, -12=one octave lower)
@@ -18,23 +18,24 @@ namespace MixedRealityExtension
         public float? Volume;
 
         /// <summary>
-        /// repeat the sound when ended, or turn it off after playing once. Default to false
+        /// repeat the media when ended, or turn it off after playing once. Default to false
         /// </summary>
         public bool? Looping;
 
         /// <summary>
-        /// pause or unpause the sound. Default to false
+        /// pause or unpause the media. Default to false
         /// </summary>
         public bool? paused;
 
         /// <summary>
         /// the amount that sound pitch is modified when moving towards/away from sound source.
         /// For music and speech, set this to 0, but for regular objects set to 1.0 or higher. Default to 1.0
+        /// This does not apply to video streams, only to sounds
         /// /// </summary>
         public float? Doppler;
 
         /// <summary>
-        /// Specify how much a sound is non-directional (playing the same volume in each speaker regardless of facing direction)
+        /// Specify how much the sound is non-directional (playing the same volume in each speaker regardless of facing direction)
         /// vs directional (playing only in the speakers that are pointing towards the sound source).
         /// This can be used to make sounds seem more "wide".
         /// It is also useful for multi-channel sounds (such as music), because a fully directional sound will always sound like mono.
@@ -43,10 +44,21 @@ namespace MixedRealityExtension
         public float? Spread;
 
         /// <summary>
-        /// Sounds will play at full volume until user is this many meters away, and then volume will decrease logarithmically
+        /// Sound will play at full volume until user is this many meters away, and then volume will decrease logarithmically
         /// Default to 1.0. For sound that needs to fill up a large space (like a concert), increase this number.
         /// </summary>
         public float? RolloffStartDistance;
 
+        /// <summary>
+        /// The media should start at, or seek this many seconds into the media.
+        /// Time is in seconds relative to start of clip.
+        /// </summary>
+        public float? Time;
+
+        /// <summary>
+        /// Should the video stream be visible or invisible
+        /// Does not apply to sounds, only to video streams
+        /// </summary>
+        public bool? Visible;
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -37,7 +37,6 @@ namespace MixedRealityExtension.Core
 
         public AudioSource TryAddSoundInstance(Actor actor, Guid id, Guid soundAssetId, SoundStateOptions options, float? startTimeOffset)
         {
-            var obj = MREAPI.AppsAPI.AssetCache.GetAsset(soundAssetId);
             var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(soundAssetId) as AudioClip;
             if (audioClip != null)
             {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -35,13 +35,13 @@ namespace MixedRealityExtension.Core
 
         #region Public Methods
 
-        public AudioSource TryAddSoundInstance(Actor actor, Guid id, Guid soundAssetId, SoundStateOptions options, float? startTimeOffset)
+        public AudioSource TryAddSoundInstance(Actor actor, Guid id, Guid soundAssetId, MediaStateOptions options, float? startTimeOffset)
         {
             var audioClip = MREAPI.AppsAPI.AssetCache.GetAsset(soundAssetId) as AudioClip;
             if (audioClip != null)
             {
                 float offset = startTimeOffset.GetValueOrDefault();
-                if (options.Looping != null && options.Looping.Value)
+                if (options.Looping != null && options.Looping.Value && audioClip.length != 0.0f)
                 {
                     offset = offset % audioClip.length;
                 }
@@ -54,7 +54,7 @@ namespace MixedRealityExtension.Core
                     soundInstance.spread = 90.0f;   //only affects multichannel sounds. Default to 50% spread, 50% stereo.
                     soundInstance.minDistance = 1.0f;
                     soundInstance.maxDistance = 1000000.0f;
-                    ApplySoundStateOptions(actor, soundInstance, options, id, true);
+                    ApplyMediaStateOptions(actor, soundInstance, options, id, true);
                     if (options.paused != null && options.paused.Value == true)
                     {
                         //start as paused
@@ -74,7 +74,7 @@ namespace MixedRealityExtension.Core
         }
 
 
-        public void ApplySoundStateOptions(Actor actor, AudioSource soundInstance, SoundStateOptions options, Guid id, bool startSound)
+        public void ApplyMediaStateOptions(Actor actor, AudioSource soundInstance, MediaStateOptions options, Guid id, bool startSound)
         {
             if (options != null)
             {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/SoundManager.cs
@@ -113,6 +113,10 @@ namespace MixedRealityExtension.Core
                     soundInstance.minDistance = options.RolloffStartDistance.Value;
                     soundInstance.maxDistance = options.RolloffStartDistance.Value * 1000000.0f;
                 }
+                if (options.Time != null)
+                {
+                    soundInstance.time=options.Time.Value;
+                }
 
                 //unpause must happen after other sound state changes
                 if (!startSound)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/VideoStreamDescription.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/VideoStreamDescription.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MixedRealityExtension.Core
+{
+    public class VideoStreamDescription : UnityEngine.ScriptableObject
+    {
+        //Duration in seconds
+        public float Duration;
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Core\SoundStateOptions.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />
+    <Compile Include="Core\VideoStreamDescription.cs" />
     <Compile Include="Factories\DefaultMaterialPatcher.cs" />
     <Compile Include="Messaging\Events\Types\ActorCorrectionEvent.cs" />
     <Compile Include="Messaging\Events\Types\ColliderEvent.cs" />
@@ -143,6 +144,8 @@
     <Compile Include="Core\Components\LookAtComponent.cs" />
     <Compile Include="Core\Text.cs" />
     <Compile Include="Factories\MWTextFactory.cs" />
+    <Compile Include="PluginInterfaces\IVideoPlayer.cs" />
+    <Compile Include="PluginInterfaces\IVideoPlayerFactory.cs" />
     <Compile Include="UnityConstants.cs" />
     <Compile Include="PluginInterfaces\Behaviors\IBehavior.cs" />
     <Compile Include="PluginInterfaces\Behaviors\IBehaviorFactory.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -102,7 +102,7 @@
     <Compile Include="Core\Interfaces\IUserInfo.cs" />
     <Compile Include="Core\SoundCommand.cs" />
     <Compile Include="Core\SoundManager.cs" />
-    <Compile Include="Core\SoundStateOptions.cs" />
+    <Compile Include="Core\MediaStateOptions.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />
     <Compile Include="Core\UserManager.cs" />
     <Compile Include="Core\VideoStreamDescription.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -100,7 +100,7 @@
     <Compile Include="Core\ColliderGeometry.cs" />
     <Compile Include="Core\Interfaces\ICollider.cs" />
     <Compile Include="Core\Interfaces\IUserInfo.cs" />
-    <Compile Include="Core\SoundCommand.cs" />
+    <Compile Include="Core\MediaCommand.cs" />
     <Compile Include="Core\SoundManager.cs" />
     <Compile Include="Core\MediaStateOptions.cs" />
     <Compile Include="Core\Types\MWVector2.cs" />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
@@ -331,7 +331,7 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// <summary>
         /// Command type (start, update, or stop)
         /// </summary>
-        public SoundCommand SoundCommand { get; set; }
+        public MediaCommand MediaCommand { get; set; }
 
         /// <summary>
         /// Time in seconds since sound was started

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/NetworkCommandPayloads.cs
@@ -311,7 +311,7 @@ namespace MixedRealityExtension.Messaging.Payloads
     /// App => Engine
     /// Payload for when the app wants to set animation state.
     /// </summary>
-    public class SetSoundState : NetworkCommandPayload
+    public class SetMediaState : NetworkCommandPayload
     {
         /// <summary>
         /// The id of the sound instance - used to manipulate the sound after instantiation
@@ -341,7 +341,7 @@ namespace MixedRealityExtension.Messaging.Payloads
         /// <summary>
         /// runtime configurable options.
         /// </summary>
-        public SoundStateOptions Options { get; set; }
+        public MediaStateOptions Options { get; set; }
 
     }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
@@ -43,7 +43,7 @@ namespace MixedRealityExtension.Messaging.Payloads
     [PayloadType(typeof(SetAnimationState), "set-animation-state")]
     [PayloadType(typeof(SetAuthoritative), "set-authoritative")]
     [PayloadType(typeof(SetBehavior), "set-behavior")]
-    [PayloadType(typeof(SetSoundState), "set-sound-state")]
+    [PayloadType(typeof(SetMediaState), "set-media-state")]
     [PayloadType(typeof(StateRestore), "state-restore")]
     [PayloadType(typeof(SyncAnimations), "sync-animations")]
     [PayloadType(typeof(SyncComplete), "sync-complete")]

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
@@ -10,8 +10,9 @@ namespace MixedRealityExtension.PluginInterfaces
 {
     public interface IVideoPlayer
     {
-        void Play(VideoStreamDescription description, SoundStateOptions options, float? startTimeOffset);
+        void Play(VideoStreamDescription description, MediaStateOptions options, float? startTimeOffset);
         void Seek(float startTimeOffset);
-        void ApplyMediaStateOptions(SoundStateOptions options);
+        void Destroy();
+        void ApplyMediaStateOptions(MediaStateOptions options);
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+using MixedRealityExtension.Core;
+namespace MixedRealityExtension.PluginInterfaces
+{
+    public interface IVideoPlayer
+    {
+        void Play(VideoStreamDescription description, SoundStateOptions options, float? startTimeOffset);
+        void Seek(float startTimeOffset);
+        void ApplyMediaStateOptions(SoundStateOptions options);
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayer.cs
@@ -11,7 +11,6 @@ namespace MixedRealityExtension.PluginInterfaces
     public interface IVideoPlayer
     {
         void Play(VideoStreamDescription description, MediaStateOptions options, float? startTimeOffset);
-        void Seek(float startTimeOffset);
         void Destroy();
         void ApplyMediaStateOptions(MediaStateOptions options);
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayerFactory.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IVideoPlayerFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UnityEngine;
+using MixedRealityExtension.Core;
+using MixedRealityExtension.Core.Interfaces;
+using MixedRealityExtension.Assets;
+using MixedRealityExtension.Util.Unity;
+
+namespace MixedRealityExtension.PluginInterfaces
+{
+
+    public struct FetchResult
+    {
+        public VideoStreamDescription Asset;
+        public string FailureMessage;
+    }
+
+    /// <summary>
+    /// A factory class that instantiates a video player
+    /// </summary>
+    public interface IVideoPlayerFactory
+    {
+        IVideoPlayer CreateVideoPlayer(IActor parent);
+        FetchResult PreloadVideoAsset(VideoSourceType videoSourceType, string uri);
+    }
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
@@ -6,7 +6,6 @@ using UnityEngine;
 namespace MixedRealityExtension.Util.Unity
 {
 
-
     public static class AssetFetcher<T> where T : class
     {
         public struct FetchResult
@@ -34,7 +33,6 @@ namespace MixedRealityExtension.Util.Unity
 
             IEnumerator LoadCoroutine()
             {
-
                 UnityEngine.Networking.UnityWebRequest www = null;
                 if (typeof(T) == typeof(AudioClip))
                 {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace MixedRealityExtension.Util.Unity
 {
 
+
     public static class AssetFetcher<T> where T : class
     {
         public struct FetchResult
@@ -33,6 +34,7 @@ namespace MixedRealityExtension.Util.Unity
 
             IEnumerator LoadCoroutine()
             {
+
                 UnityEngine.Networking.UnityWebRequest www = null;
                 if (typeof(T) == typeof(AudioClip))
                 {


### PR DESCRIPTION
As an alternative to the current AltspaceVR-exclusive RPC interface, this PR exposes a interface which Unity host apps can choose to implement, to enable streaming video players.

This interface is a work in progress - please comment, but don't merge in.

remaining work:
1. rename SetSoundState to SetMediaState (and possibly other SoundXXX names). - a bunch of sound commands are now shared with the video commands, but weren't renamed to match..
2. stop API isn't plumbed through from the SDK.
2. show/hide API not implemented
