### PR TITLE
Asset unloading

### DIFF
--- a/MRETestBed/Assets/TestBed Assets/Scripts/ResourceFactory.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/ResourceFactory.cs
@@ -8,14 +8,14 @@ using MixedRealityExtension.PluginInterfaces;
 
 public class ResourceFactory : ILibraryResourceFactory
 {
-    public async Task<GameObject> CreateFromLibrary(string resourceId, GameObject parent)
+    public Task<GameObject> CreateFromLibrary(string resourceId, GameObject parent)
     {
         var prefab = Resources.Load<GameObject>($"Library/{resourceId}");
         if (prefab == null)
         {
-            throw new ArgumentException($"Resource with ID {resourceId} not found");
+            return Task.FromException<GameObject>(new ArgumentException($"Resource with ID {resourceId} not found"));
         }
 
-        return GameObject.Instantiate(prefab, parent?.transform, false);
+        return Task.FromResult<GameObject>(GameObject.Instantiate(prefab, parent?.transform, false));
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -56,12 +56,6 @@ namespace MixedRealityExtension.Assets
             return emptyTemplate;
         }
 
-        /// <inheritdoc cref="GetAssetIdsInSource"/>
-        public IEnumerable<Guid> GetAssetIdsInSource(AssetSource source = null)
-        {
-            return cache.Where(c => c.Source == source).Select(c => c.Id);
-        }
-
         /// <inheritdoc cref="GetAsset"/>
         public Object GetAsset(Guid? id)
         {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -84,7 +84,7 @@ namespace MixedRealityExtension.Assets
         /// <inheritdoc cref="UncacheAssets"/>
         public IEnumerable<Object> UncacheAssets(Guid containerId)
         {
-            var assets = cache.Where(c => c.ContainerId == containerId).Select(c => c.Asset);
+            var assets = cache.Where(c => c.ContainerId == containerId).Select(c => c.Asset).ToArray();
             cache.RemoveAll(c => c.ContainerId == containerId);
             return assets;
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -295,6 +295,7 @@ namespace MixedRealityExtension.Assets
             if(unityAsset == null && def.Material != null)
             {
                 unityAsset = UnityEngine.Object.Instantiate(MREAPI.AppsAPI.DefaultMaterial);
+                unityAsset.name = payload.Definition.Name;
                 MREAPI.AppsAPI.AssetCache.CacheAsset(unityAsset, def.Id, payload.ContainerId);
             }
             else if(unityAsset == null && def.Texture != null)
@@ -307,6 +308,7 @@ namespace MixedRealityExtension.Assets
                 else
                 {
                     unityAsset = result.Asset;
+                    unityAsset.name = payload.Definition.Name;
                     MREAPI.AppsAPI.AssetCache.CacheAsset(unityAsset, def.Id, payload.ContainerId);
                     assignTextureToQueuedMaterials(def.Id);
                 }
@@ -321,6 +323,7 @@ namespace MixedRealityExtension.Assets
                 else
                 {
                     unityAsset = result.Asset;
+                    unityAsset.name = payload.Definition.Name;
                     MREAPI.AppsAPI.AssetCache.CacheAsset(unityAsset, def.Id, payload.ContainerId);
                 }
             }
@@ -362,6 +365,15 @@ namespace MixedRealityExtension.Assets
         {
             foreach (var asset in MREAPI.AppsAPI.AssetCache.UncacheAssets(payload.ContainerId))
             {
+                // workaround: unload meshes implicitly
+                if (asset is GameObject prefab)
+                {
+                    var filters = prefab.GetComponentsInChildren<MeshFilter>();
+                    foreach (var f in filters)
+                    {
+                        UnityEngine.Object.Destroy(f.sharedMesh);
+                    }
+                }
                 UnityEngine.Object.Destroy(asset);
             }
             onCompleteCallback?.Invoke();

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -335,7 +335,7 @@ namespace MixedRealityExtension.Assets
             {
                 if (MREAPI.AppsAPI.VideoPlayerFactory != null)
                 {
-                    MixedRealityExtension.PluginInterfaces.FetchResult result2 = MREAPI.AppsAPI.VideoPlayerFactory.PreloadVideoAsset(def.VideoStream.Value.Uri);
+                    PluginInterfaces.FetchResult result2 = MREAPI.AppsAPI.VideoPlayerFactory.PreloadVideoAsset(def.VideoStream.Value.Uri);
                     if (result2.FailureMessage != null)
                     {
                         response.FailureMessage = result2.FailureMessage;
@@ -343,7 +343,7 @@ namespace MixedRealityExtension.Assets
                     else
                     {
                         unityAsset = result2.Asset;
-                        MREAPI.AppsAPI.AssetCache.CacheAsset(unityAsset, def.Id);
+                        MREAPI.AppsAPI.AssetCache.CacheAsset(unityAsset, def.Id, payload.ContainerId);
                     }
                 }
                 else

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/AssetCommandPayloads.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/AssetCommandPayloads.cs
@@ -14,6 +14,11 @@ namespace MixedRealityExtension.Messaging.Payloads
     public class LoadAssets : NetworkCommandPayload
     {
         /// <summary>
+        /// The logical container that the new assets should be assigned to.
+        /// </summary>
+        public Guid ContainerId;
+
+        /// <summary>
         /// The asset container to load.
         /// </summary>
         public AssetSource Source;
@@ -72,8 +77,25 @@ namespace MixedRealityExtension.Messaging.Payloads
     public class CreateAsset : NetworkCommandPayload
     {
         /// <summary>
+        /// The logical container that the new assets should be assigned to.
+        /// </summary>
+        public Guid ContainerId;
+
+        /// <summary>
         /// Initial properties of the newly created asset
         /// </summary>
         public Asset Definition;
+    }
+
+    /// <summary>
+    /// App => Engine
+    /// Destroy all assets in the given container
+    /// </summary>
+    public class UnloadAssets : NetworkCommandPayload
+    {
+        /// <summary>
+        /// The container to unload
+        /// </summary>
+        public Guid ContainerId;
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Payloads/PayloadTypeRegistry.cs
@@ -49,6 +49,7 @@ namespace MixedRealityExtension.Messaging.Payloads
     [PayloadType(typeof(SyncComplete), "sync-complete")]
     [PayloadType(typeof(SyncRequest), "sync-request")]
     [PayloadType(typeof(TriggerEventRaised), "trigger-event-raised")]
+    [PayloadType(typeof(UnloadAssets), "unload-assets")]
     [PayloadType(typeof(UserJoined), "user-joined")]
     [PayloadType(typeof(UserLeft), "user-left")]
     [PayloadType(typeof(UserUpdate), "user-update")]

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
@@ -19,13 +19,6 @@ namespace MixedRealityExtension.PluginInterfaces
         GameObject EmptyTemplate();
 
         /// <summary>
-        /// Retrieve the IDs of assets loaded from a source.
-        /// </summary>
-        /// <param name="source">The asset source</param>
-        /// <returns>A list of IDs, or null if the given source is not loaded.</returns>
-        IEnumerable<Guid> GetAssetIdsInSource(AssetSource source = null);
-
-        /// <summary>
         /// Retrieve an asset from the cache by ID, or null if an asset with that ID is not loaded.
         /// </summary>
         /// <param name="id">The ID of a loaded asset.</param>

--- a/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/PluginInterfaces/IAssetCache.cs
@@ -44,7 +44,15 @@ namespace MixedRealityExtension.PluginInterfaces
         /// </summary>
         /// <param name="asset">The native Unity asset</param>
         /// <param name="id">The ID of the asset.</param>
+        /// <param name="containerId">The container ID of the asset.</param>
         /// <param name="source">The origin container.</param>
-        void CacheAsset(UnityEngine.Object asset, Guid id, AssetSource source = null);
+        void CacheAsset(UnityEngine.Object asset, Guid id, Guid containerId, AssetSource source = null);
+
+        /// <summary>
+        /// Remove assets from the cache with the given container ID.
+        /// </summary>
+        /// <param name="containerId">The container ID.</param>
+        /// <returns>The list of assets removed from the cache</returns>
+        IEnumerable<UnityEngine.Object> UncacheAssets(Guid containerId);
     }
 }


### PR DESCRIPTION
* Add a `ContainerId` field to `load-assets` and `create-asset` messages.
* Add an `unload-assets` message and handler
* Rewrite asset cache to look up by any associated field.
* Fix bug where testbed resource factory doesn't throw correctly.