### PR TITLE
Fix patching during actor creation

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -614,7 +614,8 @@ namespace MixedRealityExtension.App
             rootActor?.ApplyPatch(originalMessage.Actor);
             Actor.ApplyVisibilityUpdate(rootActor);
 
-            SendCreateActorResponse(originalMessage, actors: createdActors, onCompleteCallback: onCompleteCallback);
+            _actorManager.UponStable(
+                () => SendCreateActorResponse(originalMessage, actors: createdActors, onCompleteCallback: onCompleteCallback));
 
             void ProcessActors(Transform xfrm, Actor parent)
             {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -45,8 +45,6 @@ namespace MixedRealityExtension.Core
 
         private Dictionary<Type, ActorComponentBase> _components = new Dictionary<Type, ActorComponentBase>();
 
-        private Queue<Action<Actor>> _updateActions = new Queue<Action<Actor>>();
-
         private ActorComponentType _subscriptions = ActorComponentType.None;
 
         private ActorTransformPatch _rbTransformPatch;

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -257,12 +257,12 @@ namespace MixedRealityExtension.Core
 
         internal void SynchronizeEngine(ActorPatch actorPatch)
         {
-            _updateActions.Enqueue((actor) => ApplyPatch(actorPatch));
+            ApplyPatch(actorPatch);
         }
 
         internal void EngineCorrection(ActorCorrection actorCorrection)
         {
-            _updateActions.Enqueue((actor) => ApplyCorrection(actorCorrection));
+            ApplyCorrection(actorCorrection);
         }
 
         internal void ExecuteRigidBodyCommands(RigidBodyCommands commandPayload, Action onCompleteCallback)
@@ -457,11 +457,6 @@ namespace MixedRealityExtension.Core
         {
             try
             {
-                while (_updateActions.Count > 0)
-                {
-                    _updateActions.Dequeue()(this);
-                }
-
                 // TODO: Add ability to flag an actor for "high-frequency" updates
                 if (Time.time >= _nextUpdateTime)
                 {

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -104,13 +104,8 @@ namespace MixedRealityExtension.Core
 
         internal void ProcessActorCommand(Guid actorId, NetworkCommandPayload payload, Action onCompleteCallback)
         {
-            _actorCommandQueues.GetOrCreate(actorId, () =>
-            {
-                var queue = new ActorCommandQueue(actorId, _app);
-                _actorCommandQueues.Add(actorId, queue);
-                return queue;
-            })
-            .Enqueue(payload, onCompleteCallback);
+            _actorCommandQueues.GetOrCreate(actorId, () => new ActorCommandQueue(actorId, _app))
+                .Enqueue(payload, onCompleteCallback);
         }
 
         internal void Update(Guid actorId)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -108,14 +108,6 @@ namespace MixedRealityExtension.Core
                 .Enqueue(payload, onCompleteCallback);
         }
 
-        internal void Update(Guid actorId)
-        {
-            if (_actorCommandQueues.TryGetValue(actorId, out ActorCommandQueue queue))
-            {
-                queue.Update();
-            }
-        }
-
         internal void Update()
         {
             // _actorCommandQueues can be modified during the iteration below, so make a shallow copy.

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -6,6 +6,7 @@ using MixedRealityExtension.Core.Interfaces;
 using MixedRealityExtension.IPC;
 using MixedRealityExtension.Messaging.Commands;
 using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -103,12 +104,21 @@ namespace MixedRealityExtension.Core
 
         internal void ProcessActorCommand(Guid actorId, NetworkCommandPayload payload, Action onCompleteCallback)
         {
-            if (!_actorCommandQueues.TryGetValue(actorId, out ActorCommandQueue queue))
+            _actorCommandQueues.GetOrCreate(actorId, () =>
             {
-                queue = new ActorCommandQueue(actorId, _app);
+                var queue = new ActorCommandQueue(actorId, _app);
                 _actorCommandQueues.Add(actorId, queue);
+                return queue;
+            })
+            .Enqueue(payload, onCompleteCallback);
+        }
+
+        internal void Update(Guid actorId)
+        {
+            if (_actorCommandQueues.TryGetValue(actorId, out ActorCommandQueue queue))
+            {
+                queue.Update();
             }
-            queue.Enqueue(payload, onCompleteCallback);
         }
 
         internal void Update()


### PR DESCRIPTION
Fixes microsoft/mixed-reality-extension-sdk#386

* Get rid of actor update queues. There is already the network buffer and command queues in the actor manager. We don't need a third queue specifically for an actor's updates, it just makes the updates late.
* Process the actor command backlog before returning newly created actors in an `object-spawned` message. This prevents the returned patches from being out of date.