### PR TITLE
Clear actor command queues upon reset

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -70,6 +70,7 @@ namespace MixedRealityExtension.Core
         internal void Reset()
         {
             _actorMapping.Clear();
+            _actorCommandQueues.Clear();
         }
 
         internal Actor FindActor(Guid id)


### PR DESCRIPTION
This fixes the dreaded "timeout waiting for sync-animations" bug. When the WebSocket disconnects, we weren't clearing ActorManager's _actorCommandQueues, causing future calls to UponStable to never happen.