### PR TITLE
Clear UponStable callbacks on disconnect

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -71,6 +71,7 @@ namespace MixedRealityExtension.Core
         {
             _actorMapping.Clear();
             _actorCommandQueues.Clear();
+            _uponStable.Clear();
         }
 
         internal Actor FindActor(Guid id)


### PR DESCRIPTION
Funny interaction detected: Upon socket disconnect, we delete all the actors and actor command queues, but were failing to clear the "upon stable" callbacks. So, if there were any queued "upon stable" callbacks, clearing the actor command queues would cause them to be invoked in the next frame. Under certain conditions, this would cause the creation of new actor command queues for now-non-existant actors, and populate them with pending commands. Since these queues would never empty, the system would never again be "stable", and therefore no "upon stable" callback would happen ever again. There's a better way to clean up: delete the app instance and recreate it. I might make that change later.

This appears to have fixed the sync-animations timeout. I'm not able to repro it anymore. It's a good fix either way.