### PR TITLE
per-app logging

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -62,7 +62,7 @@ namespace MixedRealityExtension.API
 #if ANDROID_DEBUG
             Logger = logger ?? new UnityLogger(null);
 #else
-            Logger = logger ?? new ConsoleLogger();
+            Logger = logger ?? new ConsoleLogger(null);
 #endif
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -60,7 +60,7 @@ namespace MixedRealityExtension.API
             AppsAPI.EngineConstants = engineConstants;
 
 #if ANDROID_DEBUG
-            Logger = logger ?? new UnityLogger();
+            Logger = logger ?? new UnityLogger(null);
 #else
             Logger = logger ?? new ConsoleLogger();
 #endif
@@ -126,6 +126,7 @@ namespace MixedRealityExtension.API
         /// <returns>Returns the newly created mixed reality extension app.</returns>
         public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(string globalAppId, MonoBehaviour ownerScript)
         {
+
             var mreApp = new MixedRealityExtensionApp(globalAppId, ownerScript)
             {
                 InstanceId = Guid.NewGuid()

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -3,6 +3,7 @@
 using MixedRealityExtension.Core.Interfaces;
 using MixedRealityExtension.IPC;
 using MixedRealityExtension.RPC;
+using MixedRealityExtension.PluginInterfaces;
 using System;
 using UnityEngine;
 
@@ -77,6 +78,11 @@ namespace MixedRealityExtension.App
         /// The RPC interface for registering handlers and invoking remote procedure calls.
         /// </summary>
         RPCInterface RPC { get; }
+
+        /// <summary>
+        /// Gets the logger to use within the MRE SDK.
+        /// </summary>
+        IMRELogger Logger { get; }
 
         /// <summary>
         /// Connect the mixed reality extension app to the given url with the given session id.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -154,7 +154,7 @@ namespace MixedRealityExtension.App
 #if ANDROID_DEBUG
             Logger = logger ?? new UnityLogger(this);
 #else
-            Logger = logger ?? new ConsoleLogger();
+            Logger = logger ?? new ConsoleLogger(this);
 #endif
         }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -57,9 +57,6 @@ namespace MixedRealityExtension.App
         private AppState _appState = AppState.Stopped;
         private int generation = 0;
 
-        /// <summary>
-        /// Gets the logger to use within the MRE SDK.
-        /// </summary>
         public IMRELogger Logger { get; private set; }
 
         #region Events - Public
@@ -457,7 +454,7 @@ namespace MixedRealityExtension.App
 
         private void Connection_OnError(Exception ex)
         {
-            MREAPI.Logger.LogError($"Exception: {ex.Message}\nStack Trace: {ex.StackTrace}");
+            Logger.LogError($"Exception: {ex.Message}\nStack Trace: {ex.StackTrace}");
         }
 
         private void Handshake_OnOperatingModel(OperatingModel operatingModel)

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -17,8 +17,10 @@ using MixedRealityExtension.Messaging.Payloads;
 using MixedRealityExtension.Messaging.Protocols;
 using MixedRealityExtension.Patching;
 using MixedRealityExtension.Patching.Types;
+using MixedRealityExtension.PluginInterfaces;
 using MixedRealityExtension.RPC;
 using MixedRealityExtension.Util;
+using MixedRealityExtension.Util.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,6 +56,11 @@ namespace MixedRealityExtension.App
 
         private AppState _appState = AppState.Stopped;
         private int generation = 0;
+
+        /// <summary>
+        /// Gets the logger to use within the MRE SDK.
+        /// </summary>
+        public IMRELogger Logger { get; private set; }
 
         #region Events - Public
 
@@ -129,7 +136,7 @@ namespace MixedRealityExtension.App
         /// </summary>
         /// <param name="globalAppId">The global id of the app.</param>
         /// <param name="ownerScript">The owner mono behaviour script for the app.</param>
-        internal MixedRealityExtensionApp(string globalAppId, MonoBehaviour ownerScript)
+        internal MixedRealityExtensionApp(string globalAppId, MonoBehaviour ownerScript, IMRELogger logger = null)
         {
             GlobalAppId = globalAppId;
             _ownerScript = ownerScript;
@@ -147,6 +154,11 @@ namespace MixedRealityExtension.App
             });
 
             RPC = new RPCInterface(this);
+#if ANDROID_DEBUG
+            Logger = logger ?? new UnityLogger(this);
+#else
+            Logger = logger ?? new ConsoleLogger();
+#endif
         }
 
         /// <inheritdoc />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -284,7 +284,7 @@ namespace MixedRealityExtension.Assets
                 }
                 else
                 {
-                    MREAPI.Logger.LogError($"Asset {def.Id} is not patchable, or not of the right type!");
+                    _app.Logger.LogError($"Asset {def.Id} is not patchable, or not of the right type!");
                 }
                 onCompleteCallback?.Invoke();
             });
@@ -352,7 +352,7 @@ namespace MixedRealityExtension.Assets
                 catch(Exception e)
                 {
                     response.FailureMessage = e.Message;
-                    MREAPI.Logger.LogError(response.FailureMessage);
+                    _app.Logger.LogError(response.FailureMessage);
                 }
             }
             else
@@ -361,7 +361,7 @@ namespace MixedRealityExtension.Assets
                 {
                     response.FailureMessage = $"Not implemented: CreateAsset of new asset type";
                 }
-                MREAPI.Logger.LogError(response.FailureMessage);
+                _app.Logger.LogError(response.FailureMessage);
             }
 
             _app.Protocol.Send(new Message()

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerFactory.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerFactory.cs
@@ -34,8 +34,12 @@ namespace MixedRealityExtension.Behaviors
                     throw new NotImplementedException($"A handler for the behavior type {behaviorType.ToString()} exists but does not have a static create method implemented on it.");
                 }
             }
-            
-            actor.App.Logger.LogError($"Trying to create a behavior of type {behaviorType.ToString()}, but no handler is registered for the given type.");
+
+            MixedRealityExtensionApp app;
+            if (appRef.TryGetTarget(out app))
+            {
+                app.Logger.LogError($"Trying to create a behavior of type {behaviorType.ToString()}, but no handler is registered for the given type.");
+            }
             return null;
         }
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerFactory.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Behaviors/BehaviorHandlerFactory.cs
@@ -35,7 +35,7 @@ namespace MixedRealityExtension.Behaviors
                 }
             }
             
-            MREAPI.Logger.LogError($"Trying to create a behavior of type {behaviorType.ToString()}, but no handler is registered for the given type.");
+            actor.App.Logger.LogError($"Trying to create a behavior of type {behaviorType.ToString()}, but no handler is registered for the given type.");
             return null;
         }
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -1262,7 +1262,7 @@ namespace MixedRealityExtension.Core
                                 }
                                 else
                                 {
-                                    MREAPI.Logger.LogError($"Trying to start sound instance that should already have completed for: {payload.MediaAssetId}\n");
+                                    App.Logger.LogError($"Trying to start sound instance that should already have completed for: {payload.MediaAssetId}\n");
                                     _mediaInstances.Remove(payload.Id);
                                 }
                             }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -477,7 +477,7 @@ namespace MixedRealityExtension.Core
             }
             catch (Exception e)
             {
-                MREAPI.Logger.LogError($"Failed to synchronize app.  Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+                App.Logger.LogError($"Failed to synchronize app.  Exception: {e.Message}\nStackTrace: {e.StackTrace}");
             }
 
             _transformLerper?.Update();
@@ -499,7 +499,7 @@ namespace MixedRealityExtension.Core
             }
             catch (Exception e)
             {
-                MREAPI.Logger.LogError($"Failed to update rigid body.  Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+                App.Logger.LogError($"Failed to update rigid body.  Exception: {e.Message}\nStackTrace: {e.StackTrace}");
             }
         }
 
@@ -548,7 +548,7 @@ namespace MixedRealityExtension.Core
             }
             catch (Exception e)
             {
-                MREAPI.Logger.LogError($"Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+                App.Logger.LogError($"Exception: {e.Message}\nStackTrace: {e.StackTrace}");
             }
         }
 
@@ -578,7 +578,7 @@ namespace MixedRealityExtension.Core
             }
             catch (Exception e)
             {
-                MREAPI.Logger.LogError($"Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+                App.Logger.LogError($"Exception: {e.Message}\nStackTrace: {e.StackTrace}");
             }
 
             return false;
@@ -684,7 +684,7 @@ namespace MixedRealityExtension.Core
                     unityCollider = sphereCollider;
                     break;
                 default:
-                    MREAPI.Logger.LogWarning("Cannot add the given collider type to the actor " +
+                    App.Logger.LogWarning("Cannot add the given collider type to the actor " +
                         $"during runtime.  Collider Type: {colliderPatch.ColliderGeometry.ColliderType}");
                     break;
             }
@@ -1276,7 +1276,7 @@ namespace MixedRealityExtension.Core
                             }
                             else
                             {
-                                MREAPI.Logger.LogError($"Failed to start media instance with asset id: {payload.MediaAssetId}\n");
+                                App.Logger.LogError($"Failed to start media instance with asset id: {payload.MediaAssetId}\n");
                                 _mediaInstances.Remove(payload.Id);
                             }
                         });

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/ActorManager.cs
@@ -60,7 +60,7 @@ namespace MixedRealityExtension.Core
                     }
                     catch (Exception e)
                     {
-                        MREAPI.Logger.LogError(e.ToString());
+                        _app.Logger.LogError(e.ToString());
                     }
                     // Is there any other cleanup?  Do it here.
                 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Collider.cs
@@ -127,7 +127,7 @@ namespace MixedRealityExtension.Core
             }
             else
             {
-                MREAPI.Logger.LogWarning($"MRE SDK does not support the following Unity collider and will not " +
+                _ownerActor.App.Logger.LogWarning($"MRE SDK does not support the following Unity collider and will not " +
                     $"be available in the MRE app.  Collider Type: {_collider.GetType()}");
             }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Handshake.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Handshake.cs
@@ -46,7 +46,7 @@ namespace MixedRealityExtension.Messaging.Protocols
             }
             else
             {
-                MREAPI.Logger.LogDebug("Unexpected message");
+                App.Logger.LogDebug("Unexpected message");
             }
         }
     }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Protocol.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Protocol.cs
@@ -57,7 +57,7 @@ namespace MixedRealityExtension.Messaging.Protocols
             try
             {
 #if ANDROID_DEBUG
-                MREAPI.Logger.LogDebug($"Recv: {json}");
+                App.Logger.LogDebug($"Recv: {json}");
 #endif
 
                 var message = JsonConvert.DeserializeObject<Message>(json, Constants.SerializerSettings);
@@ -74,7 +74,7 @@ namespace MixedRealityExtension.Messaging.Protocols
             catch (Exception ex)
             {
                 var message = $"Failed to process message: {json}\nError: {ex.Message}\nStackTrace: {ex.StackTrace}";
-                MREAPI.Logger.LogDebug(message);
+                App.Logger.LogDebug(message);
                 try
                 {
                     // In case of failure: make a best effort to send a reply message, so promises don't hang and the app can know something about what went wrong.
@@ -124,7 +124,7 @@ namespace MixedRealityExtension.Messaging.Protocols
                 }
                 catch (Exception e)
                 {
-                    MREAPI.Logger.LogDebug($"Error serializing message. Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+                    App.Logger.LogDebug($"Error serializing message. Exception: {e.Message}\nStackTrace: {e.StackTrace}");
                 }
             }
         }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/ConsoleLogger.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/ConsoleLogger.cs
@@ -1,28 +1,52 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using MixedRealityExtension.App;
 using MixedRealityExtension.PluginInterfaces;
+using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Messaging;
 using System;
 
 namespace MixedRealityExtension.Util.Logging
 {
     internal class ConsoleLogger : IMRELogger
     {
+        MixedRealityExtensionApp _app;
+        Traces traces;
+
+        public ConsoleLogger(MixedRealityExtensionApp app)
+        {
+            _app = app;
+            traces = new Traces();
+            traces.AddTrace(new Trace() { Severity = TraceSeverity.Info, Message = null });
+        }
+
+        protected void Send(TraceSeverity severity, string message)
+        {
+            traces.Traces[0].Message = message;
+            traces.Traces[0].Severity = severity;
+            _app?.Protocol.Send(traces);
+        }
+
         /// <inheritdoc/>
         public void LogDebug(string message)
         {
             Console.WriteLine($"DEBUG: {message}");
+            Send(TraceSeverity.Debug, message);
         }
 
         /// <inheritdoc/>
         public void LogError(string message)
         {
             Console.Error.WriteLine($"ERROR: {message}");
+            Send(TraceSeverity.Error, message);
         }
 
         /// <inheritdoc/>
         public void LogWarning(string message)
         {
             Console.WriteLine($"WARNING: {message}");
+            Send(TraceSeverity.Warning, message);
         }
+
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/UnityLogger.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/UnityLogger.cs
@@ -1,28 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using MixedRealityExtension.App;
 using MixedRealityExtension.PluginInterfaces;
+using MixedRealityExtension.Messaging.Payloads;
+using MixedRealityExtension.Messaging;
 using UnityEngine;
-
 namespace MixedRealityExtension.Util.Logging
 {
     internal class UnityLogger : IMRELogger
     {
+        MixedRealityExtensionApp _app;
+        public UnityLogger(MixedRealityExtensionApp app)
+        {
+            _app = app;
+        }
+        void Send(TraceSeverity severity, string message)
+        {
+            Traces traces = new Traces();
+            traces.AddTrace(new Trace() { Severity = severity, Message = message });
+            _app?.Protocol.Send(traces);
+        }
+
         /// <inheritdoc/>
         public void LogDebug(string message)
         {
             Debug.Log($"DEBUG: {message}");
+            Send(TraceSeverity.Debug, message);
+
         }
 
         /// <inheritdoc/>
         public void LogError(string message)
         {
             Debug.LogWarning($"WARNING: {message}");
+            Send(TraceSeverity.Error, message);
         }
 
         /// <inheritdoc/>
         public void LogWarning(string message)
         {
             Debug.LogError($"ERROR: {message}");
+            Send(TraceSeverity.Warning, message);
         }
     }
 }

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/UnityLogger.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Logging/UnityLogger.cs
@@ -7,22 +7,15 @@ using MixedRealityExtension.Messaging;
 using UnityEngine;
 namespace MixedRealityExtension.Util.Logging
 {
-    internal class UnityLogger : IMRELogger
+    internal class UnityLogger : ConsoleLogger
     {
-        MixedRealityExtensionApp _app;
-        public UnityLogger(MixedRealityExtensionApp app)
+        UnityLogger(MixedRealityExtensionApp app) : base(app)
         {
-            _app = app;
-        }
-        void Send(TraceSeverity severity, string message)
-        {
-            Traces traces = new Traces();
-            traces.AddTrace(new Trace() { Severity = severity, Message = message });
-            _app?.Protocol.Send(traces);
         }
 
+
         /// <inheritdoc/>
-        public void LogDebug(string message)
+        public new void LogDebug(string message)
         {
             Debug.Log($"DEBUG: {message}");
             Send(TraceSeverity.Debug, message);
@@ -30,14 +23,14 @@ namespace MixedRealityExtension.Util.Logging
         }
 
         /// <inheritdoc/>
-        public void LogError(string message)
+        public new void LogError(string message)
         {
             Debug.LogWarning($"WARNING: {message}");
             Send(TraceSeverity.Error, message);
         }
 
         /// <inheritdoc/>
-        public void LogWarning(string message)
+        public new void LogWarning(string message)
         {
             Debug.LogError($"ERROR: {message}");
             Send(TraceSeverity.Warning, message);


### PR DESCRIPTION
currently unity-side logging is printed to the unity log only. Ideally MRE Authors should be able to see the unity errors.  This PR adds a per-app logger class, which sends every logged message back to the MRE.

This is the Unity side of the PR. It works without SDK change.

We should also make the server say which level of logging it cares to receive - no need to waste bandwidth on diagnostics data that isn't looked at.

Caveat: This was only added to places that can access the App (maybe 65% of all places) - a number of static functions don't know which app they work for (or work for more than one app), so they will keep the old logger - most of those don't need to be brought over..