### PR TITLE
Don't throw if asset is already cached.

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -95,12 +95,11 @@ namespace MixedRealityExtension.Assets
         /// <inheritdoc cref="CacheAsset"/>
         public void CacheAsset(Object asset, Guid id, Guid containerId, AssetSource source = null)
         {
-            if (cache.Any(c => c.Id == id))
+            if (!cache.Any(c => c.Id == id))
             {
-                throw new Exception($"An asset with ID {id} is already cached!");
+                cache.Add(new CacheEntry(id, containerId, source, asset));
             }
 
-            cache.Add(new CacheEntry(id, containerId, source, asset));
             if (cacheCallbacks.TryGetValue(id, out List<CacheCallback> callbacks))
             {
                 cacheCallbacks.Remove(id);


### PR DESCRIPTION
AssetCache was throwing and exception if an asset was already cached. This breaks cases where the same MRE is running multiple instances of the same session in the same space. Specifically, this breaks running multiple instances of video-test by interrupting code execution at mixed-reality-extension-unity\MREUnityRuntime\MREUnityRuntimeLib\Assets\AssetLoader.cs(339). We never reply to the app, so it doesn't start the video.

Because we support sharing assets between multiple MRE instances in a space, I don't think this is an error condition in the first place.

Related: I think we're throwing too many exceptions where we should be instead logging errors and gracefully exiting the codepath (returning error codes back to the app, etc.). I'll log an issue for review of each exception we throw.