### PR TITLE
Expose ServerUrl on IMixedRealityExtensionApp.

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -80,6 +80,11 @@ namespace MixedRealityExtension.App
 		bool IsActive { get; }
 
 		/// <summary>
+		/// The url of the MRE server. Only valid after `Startup` has been called.
+		/// </summary>
+		string ServerUrl { get; }
+
+		/// <summary>
 		/// The game object that serves as the scene root.
 		/// </summary>
 		GameObject SceneRoot { get; set; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -105,6 +105,9 @@ namespace MixedRealityExtension.App
 		public bool IsActive => _conn?.IsActive ?? false;
 
 		/// <inheritdoc />
+		public string ServerUrl { get; private set; }
+
+		/// <inheritdoc />
 		public GameObject SceneRoot { get; set; }
 
 		/// <inheritdoc />
@@ -174,6 +177,8 @@ namespace MixedRealityExtension.App
 		/// <inheritdoc />
 		public void Startup(string url, string sessionId, string platformId)
 		{
+			ServerUrl = url;
+
 			if (_conn == null)
 			{
 				if (_appState == AppState.Stopped)


### PR DESCRIPTION
Needed by WebProjector, so it can derive the streaming url from the MRE url.