### PR TITLE
Update testbed and DLL dependency to Unity 2019.2.12f1

### DIFF
--- a/MRETestBed/ProjectSettings/ProjectVersion.txt
+++ b/MRETestBed/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,2 @@
-m_EditorVersion: 2018.1.9f2
+m_EditorVersion: 2019.2.12f1
+m_EditorVersionWithRevision: 2019.2.12f1 (b1a7e1fb4fa5)

--- a/MRETestBed/ProjectSettings/VFXManager.asset
+++ b/MRETestBed/ProjectSettings/VFXManager.asset
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!937362698 &1
+VFXManager:
+  m_ObjectHideFlags: 0
+  m_IndirectShader: {fileID: 0}
+  m_CopyBufferShader: {fileID: 0}
+  m_SortShader: {fileID: 0}
+  m_RenderPipeSettingsPath: 
+  m_FixedTimeStep: 0.016666668
+  m_MaxDeltaTime: 0.05

--- a/MRETestBed/ProjectSettings/XRSettings.asset
+++ b/MRETestBed/ProjectSettings/XRSettings.asset
@@ -1,0 +1,10 @@
+{
+    "m_SettingKeys": [
+        "VR Device Disabled",
+        "VR Device User Alert"
+    ],
+    "m_SettingValues": [
+        "False",
+        "False"
+    ]
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -20,7 +20,7 @@
     <UnityProjectGenerator>Unity/VSTU</UnityProjectGenerator>
     <UnityProjectType>Game:1</UnityProjectType>
     <UnityBuildTarget>StandaloneWindows:5</UnityBuildTarget>
-    <UnityVersion>2018.1.9f2</UnityVersion>
+    <UnityVersion>2019.2.12f1</UnityVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Built and loaded the project in Unity 2019.2.12f1, and surprisingly didn't hit any problems at all. I was expecting something because of microsoft/mixed-reality-extension-sdk#332, but didn't reproduce those errors.