### PR TITLE
Don't assume LocalUser is defined

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -71,7 +71,7 @@ namespace MixedRealityExtension.App
 		string SessionId { get; }
 
 		/// <summary>
-		/// Gets the local user
+		/// Gets the local user. Will be null if the local client has not joined as a user.
 		/// </summary>
 		IUser LocalUser { get; }
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/Actor.cs
@@ -1310,7 +1310,7 @@ namespace MixedRealityExtension.Core
 
 			Attachment attachmentInHierarchy = FindAttachmentInHierarchy();
 			bool inAttachmentHeirarchy = (attachmentInHierarchy != null);
-			bool inOwnedAttachmentHierarchy = (inAttachmentHeirarchy && attachmentInHierarchy.UserId == LocalUser.Id);
+			bool inOwnedAttachmentHierarchy = (inAttachmentHeirarchy && LocalUser != null && attachmentInHierarchy.UserId == LocalUser.Id);
 
 			// Don't sync anything if the actor is in an attachment hierarchy on a remote avatar.
 			if (inAttachmentHeirarchy && !inOwnedAttachmentHierarchy)
@@ -1341,7 +1341,7 @@ namespace MixedRealityExtension.Core
 
 			Attachment attachmentInHierarchy = FindAttachmentInHierarchy();
 			bool inAttachmentHeirarchy = (attachmentInHierarchy != null);
-			bool inOwnedAttachmentHierarchy = (inAttachmentHeirarchy && attachmentInHierarchy.UserId == LocalUser.Id);
+			bool inOwnedAttachmentHierarchy = (inAttachmentHeirarchy && LocalUser != null && attachmentInHierarchy.UserId == LocalUser.Id);
 
 			// We can send actor updates to the app if we're operating in a server-authoritative model,
 			// or if we're in a peer-authoritative model and we've been designated the authoritative peer.

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/MixedRealityExtensionObject.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/MixedRealityExtensionObject.cs
@@ -27,6 +27,9 @@ namespace MixedRealityExtension.Core
 
 		internal MixedRealityExtensionApp App { get; private set; }
 
+		/// <summary>
+		/// Gets the local user. Will be null if the local client has not joined as a user.
+		/// </summary>
 		public IUser LocalUser => App.LocalUser;
 
 		public void Initialize(Guid id, MixedRealityExtensionApp app)


### PR DESCRIPTION
There is no guarantee that a given client has a local user, so don't assume there is one.