### PR TITLE
Limit concurrent web requests

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoadThrottling.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoadThrottling.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MixedRealityExtension.Assets
+{
+	/// <summary>
+	/// Global asset load web request throttler.
+	/// </summary>
+	internal static class AssetLoadThrottling
+	{
+		// Global: Keep track of the number of active asset fetch web requests.
+		const int MaxActiveLoads = 4;
+		private static int ActiveLoads = 0;
+
+		public static bool WouldThrottle()
+		{
+			return ActiveLoads >= MaxActiveLoads;
+		}
+
+		public static async Task<AssetLoadScope> AcquireLoadScope()
+		{
+			// Spin asynchronously until there is room for this load scope.
+			while (WouldThrottle())
+			{
+				await Task.Delay(10);
+			}
+
+			return new AssetLoadScope();
+		}
+
+		public class AssetLoadScope : IDisposable
+		{
+            public AssetLoadScope()
+			{
+				++ActiveLoads;
+			}
+
+			private bool disposedValue = false;
+
+			protected virtual void Dispose(bool disposing)
+			{
+				if (!disposedValue)
+				{
+					if (disposing)
+					{
+						--ActiveLoads;
+					}
+					disposedValue = true;
+				}
+			}
+
+			public void Dispose()
+			{
+				Dispose(true);
+			}
+		}
+	}
+}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -199,99 +199,100 @@ namespace MixedRealityExtension.Assets
 			//GLTF.GLTFParser.ParseJson(stream, out GLTF.Schema.GLTFRoot gltfRoot);
 			stream.Position = 0;
 
-			GLTFSceneImporter importer =
-				MREAPI.AppsAPI.GLTFImporterFactory.CreateImporter(gltfRoot, loader, _asyncHelper, stream);
-			importer.SceneParent = MREAPI.AppsAPI.AssetCache.CacheRootGO().transform;
-			importer.Collider = colliderType.ToGLTFColliderType();
-
-			// load textures
-			if (gltfRoot.Textures != null)
+			using (GLTFSceneImporter importer =
+				MREAPI.AppsAPI.GLTFImporterFactory.CreateImporter(gltfRoot, loader, _asyncHelper, stream))
 			{
-				for (var i = 0; i < gltfRoot.Textures.Count; i++)
+				importer.SceneParent = MREAPI.AppsAPI.AssetCache.CacheRootGO().transform;
+				importer.Collider = colliderType.ToGLTFColliderType();
+
+				// load textures
+				if (gltfRoot.Textures != null)
 				{
-					await importer.LoadTextureAsync(gltfRoot.Textures[i], i, true);
-					var texture = importer.GetTexture(i);
-					texture.name = gltfRoot.Textures[i].Name ?? $"texture:{i}";
-
-					var asset = GenerateAssetPatch(texture, guidGenerator.Next());
-					asset.Name = texture.name;
-					asset.Source = new AssetSource(source.ContainerType, source.Uri, $"texture:{i}");
-					MREAPI.AppsAPI.AssetCache.CacheAsset(texture, asset.Id, containerId, source);
-					assets.Add(asset);
-				}
-			}
-
-			// load meshes
-			if (gltfRoot.Meshes != null)
-			{
-				var cancellationSource = new System.Threading.CancellationTokenSource();
-				for (var i = 0; i < gltfRoot.Meshes.Count; i++)
-				{
-					var mesh = await importer.LoadMeshAsync(i, cancellationSource.Token);
-					mesh.name = gltfRoot.Meshes[i].Name ?? $"mesh:{i}";
-
-					var asset = GenerateAssetPatch(mesh, guidGenerator.Next());
-					asset.Name = mesh.name;
-					asset.Source = new AssetSource(source.ContainerType, source.Uri, $"mesh:{i}");
-					var colliderGeo = colliderType == ColliderType.Mesh ?
-						(ColliderGeometry)new MeshColliderGeometry() { MeshId = asset.Id } :
-						(ColliderGeometry)new BoxColliderGeometry() { Size = (mesh.bounds.size * 0.8f).CreateMWVector3() };
-					MREAPI.AppsAPI.AssetCache.CacheAsset(mesh, asset.Id, containerId, source, colliderGeo);
-					assets.Add(asset);
-				}
-			}
-
-			// load materials
-			if (gltfRoot.Materials != null)
-			{
-				for (var i = 0; i < gltfRoot.Materials.Count; i++)
-				{
-					var matdef = gltfRoot.Materials[i];
-					var material = await importer.LoadMaterialAsync(i);
-					material.name = matdef.Name ?? $"material:{i}";
-
-					var asset = GenerateAssetPatch(material, guidGenerator.Next());
-					asset.Name = material.name;
-					asset.Source = new AssetSource(source.ContainerType, source.Uri, $"material:{i}");
-					MREAPI.AppsAPI.AssetCache.CacheAsset(material, asset.Id, containerId, source);
-					assets.Add(asset);
-				}
-			}
-
-			// load prefabs
-			if (gltfRoot.Scenes != null)
-			{
-				for (var i = 0; i < gltfRoot.Scenes.Count; i++)
-				{
-					await importer.LoadSceneAsync(i).ConfigureAwait(true);
-
-					GameObject rootObject = importer.LastLoadedScene;
-					rootObject.name = gltfRoot.Scenes[i].Name ?? $"scene:{i}";
-
-					var animation = rootObject.GetComponent<UnityEngine.Animation>();
-					if (animation != null)
+					for (var i = 0; i < gltfRoot.Textures.Count; i++)
 					{
-						animation.playAutomatically = false;
+						await importer.LoadTextureAsync(gltfRoot.Textures[i], i, true);
+						var texture = importer.GetTexture(i);
+						texture.name = gltfRoot.Textures[i].Name ?? $"texture:{i}";
 
-						// initialize mapping so we know which gameobjects are targeted by which animation clips
-						var mapping = rootObject.AddComponent<PrefabAnimationTargets>();
-						mapping.Initialize(gltfRoot, i);
+						var asset = GenerateAssetPatch(texture, guidGenerator.Next());
+						asset.Name = texture.name;
+						asset.Source = new AssetSource(source.ContainerType, source.Uri, $"texture:{i}");
+						MREAPI.AppsAPI.AssetCache.CacheAsset(texture, asset.Id, containerId, source);
+						assets.Add(asset);
 					}
+				}
 
-					MWGOTreeWalker.VisitTree(rootObject, (go) =>
+				// load meshes
+				if (gltfRoot.Meshes != null)
+				{
+					var cancellationSource = new System.Threading.CancellationTokenSource();
+					for (var i = 0; i < gltfRoot.Meshes.Count; i++)
 					{
-						go.layer = MREAPI.AppsAPI.LayerApplicator.DefaultLayer;
-					});
+						var mesh = await importer.LoadMeshAsync(i, cancellationSource.Token);
+						mesh.name = gltfRoot.Meshes[i].Name ?? $"mesh:{i}";
 
-					var def = GenerateAssetPatch(rootObject, guidGenerator.Next());
-					def.Name = rootObject.name;
-					def.Source = new AssetSource(source.ContainerType, source.Uri, $"scene:{i}");
-					MREAPI.AppsAPI.AssetCache.CacheAsset(rootObject, def.Id, containerId, source);
-					assets.Add(def);
+						var asset = GenerateAssetPatch(mesh, guidGenerator.Next());
+						asset.Name = mesh.name;
+						asset.Source = new AssetSource(source.ContainerType, source.Uri, $"mesh:{i}");
+						var colliderGeo = colliderType == ColliderType.Mesh ?
+							(ColliderGeometry)new MeshColliderGeometry() { MeshId = asset.Id } :
+							(ColliderGeometry)new BoxColliderGeometry() { Size = (mesh.bounds.size * 0.8f).CreateMWVector3() };
+						MREAPI.AppsAPI.AssetCache.CacheAsset(mesh, asset.Id, containerId, source, colliderGeo);
+						assets.Add(asset);
+					}
+				}
+
+				// load materials
+				if (gltfRoot.Materials != null)
+				{
+					for (var i = 0; i < gltfRoot.Materials.Count; i++)
+					{
+						var matdef = gltfRoot.Materials[i];
+						var material = await importer.LoadMaterialAsync(i);
+						material.name = matdef.Name ?? $"material:{i}";
+
+						var asset = GenerateAssetPatch(material, guidGenerator.Next());
+						asset.Name = material.name;
+						asset.Source = new AssetSource(source.ContainerType, source.Uri, $"material:{i}");
+						MREAPI.AppsAPI.AssetCache.CacheAsset(material, asset.Id, containerId, source);
+						assets.Add(asset);
+					}
+				}
+
+				// load prefabs
+				if (gltfRoot.Scenes != null)
+				{
+					for (var i = 0; i < gltfRoot.Scenes.Count; i++)
+					{
+						await importer.LoadSceneAsync(i).ConfigureAwait(true);
+
+						GameObject rootObject = importer.LastLoadedScene;
+						rootObject.name = gltfRoot.Scenes[i].Name ?? $"scene:{i}";
+
+						var animation = rootObject.GetComponent<UnityEngine.Animation>();
+						if (animation != null)
+						{
+							animation.playAutomatically = false;
+
+							// initialize mapping so we know which gameobjects are targeted by which animation clips
+							var mapping = rootObject.AddComponent<PrefabAnimationTargets>();
+							mapping.Initialize(gltfRoot, i);
+						}
+
+						MWGOTreeWalker.VisitTree(rootObject, (go) =>
+						{
+							go.layer = MREAPI.AppsAPI.LayerApplicator.DefaultLayer;
+						});
+
+						var def = GenerateAssetPatch(rootObject, guidGenerator.Next());
+						def.Name = rootObject.name;
+						def.Source = new AssetSource(source.ContainerType, source.Uri, $"scene:{i}");
+						MREAPI.AppsAPI.AssetCache.CacheAsset(rootObject, def.Id, containerId, source);
+						assets.Add(def);
+					}
 				}
 			}
 
-			importer.Dispose();
 			return assets;
 		}
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -12,8 +12,8 @@ using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.Util;
 using MixedRealityExtension.Util.Unity;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -24,7 +24,6 @@ using MWTexture = MixedRealityExtension.Assets.Texture;
 using MWMesh = MixedRealityExtension.Assets.Mesh;
 using MWSound = MixedRealityExtension.Assets.Sound;
 using MWVideoStream = MixedRealityExtension.Assets.VideoStream;
-using System.IO;
 
 namespace MixedRealityExtension.Assets
 {
@@ -180,12 +179,19 @@ namespace MixedRealityExtension.Assets
 			}
 
 			// pre-parse glTF document so we can get a scene count
-			// run this asynchronously
+			// run this on a threadpool thread so that the Unity main thread is not blocked
 			GLTF.Schema.GLTFRoot gltfRoot = null;
-			await Task.Run(() =>
+			try
 			{
-				GLTF.GLTFParser.ParseJson(stream, out gltfRoot);
-			});
+				await Task.Run(() =>
+				{
+					GLTF.GLTFParser.ParseJson(stream, out gltfRoot);
+				});
+			}
+			catch (Exception e)
+			{
+				Debug.LogError(e);
+			}
 			if (gltfRoot == null)
 			{
 				throw new GLTFLoadException("Failed to parse glTF");

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -165,7 +165,7 @@ namespace MixedRealityExtension.Assets
 			try
 			{
 				// Increment activeLoads
-				Interlocked.Increment(ref activeLoads);
+				++activeLoads;
 
 				// download file
 				var rootUrl = URIHelper.GetDirectoryName(source.ParsedUri.AbsoluteUri);
@@ -175,7 +175,7 @@ namespace MixedRealityExtension.Assets
 			finally
 			{
 				// Decrement activeLoads
-				Interlocked.Decrement(ref activeLoads);
+				--activeLoads;
 			}
 
 			// pre-parse glTF document so we can get a scene count

--- a/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
+++ b/MREUnityRuntime/MREUnityRuntimeLib/MREUnityRuntimeLib.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Animation\MWSetAnimationStateOptions.cs" />
     <Compile Include="Animation\NativeAnimation.cs" />
     <Compile Include="Animation\TargetPath.cs" />
+    <Compile Include="Assets\AssetLoadThrottling.cs" />
     <Compile Include="Assets\PrefabAnimationTargets.cs" />
     <Compile Include="Core\CollisionLayers.cs" />
     <Compile Include="Assets\AssetCache.cs" />
@@ -287,7 +288,7 @@
     <Compile Include="Util\Unity\MWGOTreeWalker.cs" />
     <Compile Include="Util\Unity\MWUnityHelpers.cs" />
     <Compile Include="Util\Unity\MWUnityTypeExtensions.cs" />
-    <Compile Include="Util\Unity\AssetFetcher.cs" />
+    <Compile Include="Assets\AssetFetcher.cs" />
     <Compile Include="Util\UtilMethods.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Util/Unity/AssetFetcher.cs
@@ -66,7 +66,7 @@ namespace MixedRealityExtension.Util.Unity
 				using (var www = new UnityWebRequest(uri, "GET", handler, null))
 				{
 					// Increment activeLoads
-					Interlocked.Increment(ref activeLoads);
+					++activeLoads;
 
 					yield return www.SendWebRequest();
 					if (www.isNetworkError)
@@ -90,7 +90,7 @@ namespace MixedRealityExtension.Util.Unity
 					}
 
 					// Decrement activeLoads
-					Interlocked.Decrement(ref activeLoads);
+					--activeLoads;
 				}
 			}
 		}


### PR DESCRIPTION
This is a quick fix to stabilize AltQuiz. Globally limit the number of concurrent asset fetch web requests in the MRE runtime.