### PR TITLE
Improved texture rendering

### DIFF
--- a/MRETestBed/Assets/TestBed Assets/Shaders/MREDiffuseVertex.shader
+++ b/MRETestBed/Assets/TestBed Assets/Shaders/MREDiffuseVertex.shader
@@ -8,19 +8,17 @@ Shader "MRE/DiffuseVertex" {
 		_EmissiveTex ("Emissive Texture", 2D) = "white" {}
 
 		// Blend settings
-		_AlphaCutoff("Alpha Cutoff", Range(0,1)) = 0.5
-		[HideInInspector] _ShouldCutout("__should_cutout", Float) = 0.0
 		[HideInInspector] _SrcBlend("__src", Float) = 1.0
 		[HideInInspector] _DstBlend("__dst", Float) = 0.0
 		[HideInInspector] _ZWrite("__zw", Float) = 1.0
 	}
 	SubShader {
-		Tags { "RenderMode" = "Opaque" "Queue" = "Geometry" }
+		Tags { "RenderMode" = "Transparent" "Queue" = "Geometry" }
 		LOD 200
 
 		Pass {
 			Tags { "LightMode" = "Vertex" }
-			Blend [_SrcBlend] [_DstBlend]
+            Blend SrcAlpha OneMinusSrcAlpha
 			ZWrite [_ZWrite]
 
 			CGPROGRAM
@@ -38,8 +36,6 @@ Shader "MRE/DiffuseVertex" {
 
 			uniform float4 _Color;
 			uniform float4 _EmissiveColor;
-			uniform float _ShouldCutout;
-			uniform float _AlphaCutoff;
 
 			struct appdata
 			{
@@ -122,7 +118,7 @@ Shader "MRE/DiffuseVertex" {
 					fixed4(_EmissiveColor.rgb, 0.0) * tex2D(_EmissiveTex, TRANSFORM_TEX(i.uv, _EmissiveTex)) +
 					i.diffuse * tex2D(_MainTex, TRANSFORM_TEX(i.uv, _MainTex));
 				UNITY_APPLY_FOG(i.fogCoord, color);
-				clip(lerp(1, color.a - _AlphaCutoff, _ShouldCutout));
+				clip(lerp(1, color.a, 0));
 				return color;
 			}
 			ENDCG

--- a/MRETestBed/Assets/TestBed Assets/Shaders/MREDiffuseVertex.shader
+++ b/MRETestBed/Assets/TestBed Assets/Shaders/MREDiffuseVertex.shader
@@ -18,7 +18,7 @@ Shader "MRE/DiffuseVertex" {
 
 		Pass {
 			Tags { "LightMode" = "Vertex" }
-            Blend SrcAlpha OneMinusSrcAlpha
+			Blend SrcAlpha OneMinusSrcAlpha
 			ZWrite [_ZWrite]
 
 			CGPROGRAM

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetFetcher.cs
@@ -43,7 +43,7 @@ namespace MixedRealityExtension.Assets
 				{
 					handler = new DownloadHandlerAudioClip(uri, AudioType.UNKNOWN);
 				}
-				else if (typeof(T) == typeof(UnityEngine.Texture))
+				else if (typeof(T) == typeof(UnityEngine.Texture2D))
 				{
 					handler = new DownloadHandlerTexture(false);
 				}
@@ -77,7 +77,7 @@ namespace MixedRealityExtension.Assets
 						{
 							result.Asset = ((DownloadHandlerAudioClip)handler).audioClip as T;
 						}
-						else if (typeof(T) == typeof(UnityEngine.Texture))
+						else if (typeof(T) == typeof(UnityEngine.Texture2D))
 						{
 							result.Asset = ((DownloadHandlerTexture)handler).texture as T;
 						}

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -292,7 +292,7 @@ namespace MixedRealityExtension.Assets
 				if (!_owner) return;
 
 				var mat = asset as UnityEngine.Material;
-				var tex = asset as UnityEngine.Texture;
+				var tex = asset as UnityEngine.Texture2D;
 				if (def.Material != null)
 				{
 					MREAPI.AppsAPI.MaterialPatcher.ApplyMaterialPatch(_app, mat, def.Material.Value);
@@ -355,11 +355,18 @@ namespace MixedRealityExtension.Assets
 			// create textures
 			else if (unityAsset == null && def.Texture != null)
 			{
-				var result = await AssetFetcher<UnityEngine.Texture>.LoadTask(_owner, new Uri(def.Texture.Value.Uri));
-				unityAsset = result.Asset;
+				var result = await AssetFetcher<UnityEngine.Texture2D>.LoadTask(_owner, new Uri(def.Texture.Value.Uri));
 				if (result.FailureMessage != null)
 				{
 					response.FailureMessage = result.FailureMessage;
+				}
+				else
+				{
+					var wwwTexture = result.Asset;
+					var mipTexture = new Texture2D(wwwTexture.width, wwwTexture.height, wwwTexture.format, true, false);
+					Graphics.CopyTexture(wwwTexture, 0, 0, mipTexture, 0, 0);
+					mipTexture.Apply(true);
+					unityAsset = mipTexture;
 				}
 			}
 
@@ -499,7 +506,7 @@ namespace MixedRealityExtension.Assets
 					Material = MREAPI.AppsAPI.MaterialPatcher.GeneratePatch(_app, mat)
 				};
 			}
-			else if (unityAsset is UnityEngine.Texture tex)
+			else if (unityAsset is UnityEngine.Texture2D tex)
 			{
 				return new Asset()
 				{


### PR DESCRIPTION
Textures downloaded by MREs render very aliased. This is largely due to: no mipmaps, no alpha blending. Changes in this PR:
* Generate mipmaps on downloaded textures
* Enable alpha blending in shader