### PR TITLE
Fix testing bugs

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetFetcher.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetFetcher.cs
@@ -100,7 +100,7 @@ namespace MixedRealityExtension.Assets
 					else
 					{
 						result.ReturnCode = www.responseCode;
-						result.ETag = www.GetResponseHeader("ETag");
+						result.ETag = www.GetResponseHeader("ETag") ?? "unversioned";
 
 						if (www.isHttpError)
 						{

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -182,7 +182,7 @@ namespace MixedRealityExtension.Assets
 				try
 				{
 					stream = await loader.LoadStreamAsync(URIHelper.GetFileFromUri(source.ParsedUri));
-					source.Version = loader.LastResponse.Headers.ETag.Tag;
+					source.Version = loader.LastResponse.Headers.ETag?.Tag ?? "unversioned";
 				}
 				catch (HttpRequestException httpErr)
 				{

--- a/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Protocol.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Messaging/Protocols/Protocol.cs
@@ -120,7 +120,8 @@ namespace MixedRealityExtension.Messaging.Protocols
 				}
 				catch (Exception e)
 				{
-					App.Logger.LogDebug($"Error sending message. Exception: {e.Message}\nStackTrace: {e.StackTrace}");
+					// Don't log to App.Logger here. The WebSocket might be disconnected.
+					Debug.LogError($"Error sending message. Exception: {e.Message}\nStackTrace: {e.StackTrace}");
 				}
 			}
 		}


### PR DESCRIPTION
* Don't fail if asset load responses don't contain ETag headers
* Don't log connection failures back to (disconnected) server