### PR TITLE
Don't overwrite asset cache GO with null

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -83,7 +83,10 @@ namespace MixedRealityExtension.Assets
 
 		protected virtual void Start()
 		{
-			CacheRootGO = SerializedCacheRoot;
+			if (SerializedCacheRoot != null)
+			{
+				CacheRootGO = SerializedCacheRoot;
+			}
 			Application.lowMemory += CleanUnusedResources;
 		}
 


### PR DESCRIPTION
The asset cache root game object can be initialized either directly in code, or from a serialized field on the MonoBehaviour that is assigned over on `Start`. If it's set it code, don't stomp it with the uninitialized serialized field. Only affects test bed, which uses the code path.