### PR TITLE
Distinguish between no cached item, and unversioned cache item

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -182,7 +182,7 @@ namespace MixedRealityExtension.Assets
 				try
 				{
 					stream = await loader.LoadStreamAsync(URIHelper.GetFileFromUri(source.ParsedUri));
-					source.Version = loader.LastResponse.Headers.ETag?.Tag ?? "unversioned";
+					source.Version = loader.LastResponse.Headers.ETag?.Tag ?? "";
 				}
 				catch (HttpRequestException)
 				{


### PR DESCRIPTION
`IAssetCache.GetVersion` returns null if no content was found, so a cached asset's version cannot be `null`, even if a server does not supply an ETag header. However, it also has to be a valid ETag. Going with the empty string here, to distinguish between both null and a real ETag.