### PR TITLE
Initialize asset cache earlier

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -90,6 +90,11 @@ namespace MixedRealityExtension.Assets
 			Application.lowMemory += CleanUnusedResources;
 		}
 
+		protected virtual void OnDestroy()
+		{
+			Application.lowMemory -= CleanUnusedResources;
+		}
+
 		///<inheritdoc/>
 		public virtual void StoreAssets(Uri uri, IEnumerable<Object> assets, string version)
 		{

--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetCache.cs
@@ -81,7 +81,7 @@ namespace MixedRealityExtension.Assets
 		/// <inheritdoc />
 		public bool SupportsSync { get; protected set; } = true;
 
-		protected virtual void Start()
+		protected virtual void Awake()
 		{
 			if (SerializedCacheRoot != null)
 			{


### PR DESCRIPTION
By moving the init to `Awake()` instead of `Start()`, MREs can be connected in `Start()` without causing problems.