### PR TITLE
Change assumptions to 'UserJoin' all users, not just local ones

### DIFF
--- a/MRETestBed/Assets/Scenes/HelloWorld.unity
+++ b/MRETestBed/Assets/Scenes/HelloWorld.unity
@@ -96,6 +96,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -219,6 +220,7 @@ MonoBehaviour:
   MREURL: ws://mres.altvr.com/helloworld
   SessionID: testbed
   AppID: helloworld
+  EphemeralAppID: helloworld-temp
   UserProperties: []
   AutoStart: 0
   AutoJoin: 1
@@ -361,6 +363,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -432,8 +435,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1966163891}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1
   m_Range: 10

--- a/MRETestBed/Assets/Scenes/Standalone.unity
+++ b/MRETestBed/Assets/Scenes/Standalone.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 1966163892}
-  m_IndirectSpecularColor: {r: 0, g: 0.99999946, b: 0.99999946, a: 1}
+  m_IndirectSpecularColor: {r: 0.45135576, g: 0.500937, b: 0.57278883, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -232,6 +232,7 @@ MonoBehaviour:
   MREURL: ws://localhost:3901
   SessionID: testbed
   AppID: helloworld
+  EphemeralAppID: helloworld-temp
   UserProperties: []
   AutoStart: 0
   AutoJoin: 1

--- a/MRETestBed/Assets/Scenes/SynchronizationTest-localhost.unity
+++ b/MRETestBed/Assets/Scenes/SynchronizationTest-localhost.unity
@@ -96,6 +96,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -184,6 +185,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -289,7 +291,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MREURL: ws://localhost:3901
   SessionID: foo
-  AppID: 
+  AppID: solar-system-app
+  EphemeralAppID: ss-temp
   UserProperties: []
   AutoStart: 0
   AutoJoin: 1
@@ -416,8 +419,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1042221608}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -515,6 +519,7 @@ MonoBehaviour:
   MREURL: ws://localhost:3901
   SessionID: foo
   AppID: solar-system-app
+  EphemeralAppID: ss-temp
   UserProperties: []
   AutoStart: 0
   AutoJoin: 1
@@ -799,6 +804,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/MRETestBed/Assets/Scenes/TriggerVolumeTestBed-localhost.unity
+++ b/MRETestBed/Assets/Scenes/TriggerVolumeTestBed-localhost.unity
@@ -96,6 +96,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -205,8 +206,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 170076733}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -370,6 +372,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -432,6 +435,7 @@ MonoBehaviour:
   MREURL: ws://localhost:3901
   SessionID: Foo
   AppID: Test App
+  EphemeralAppID: temp
   UserProperties: []
   AutoStart: 0
   AutoJoin: 1
@@ -493,6 +497,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/MRETestBed/Assets/TestBed Assets/Scripts/MREComponent.cs
+++ b/MRETestBed/Assets/TestBed Assets/Scripts/MREComponent.cs
@@ -50,6 +50,8 @@ public class MREComponent : MonoBehaviour
 
 	public string AppID;
 
+	public string EphemeralAppID;
+
 	[Serializable]
 	public class UserProperty
 	{
@@ -144,7 +146,7 @@ public class MREComponent : MonoBehaviour
 			_apiInitialized = true;
 		}
 
-		MREApp = MREAPI.AppsAPI.CreateMixedRealityExtensionApp(this, AppID);
+		MREApp = MREAPI.AppsAPI.CreateMixedRealityExtensionApp(this, EphemeralAppID, AppID);
 
 		if (SceneRoot == null)
 		{
@@ -340,7 +342,7 @@ public class MREComponent : MonoBehaviour
 			hostAppUser.Properties[kv.Name] = kv.Value;
 		}
 
-		MREApp?.UserJoin(UserGameObject, hostAppUser);
+		MREApp?.UserJoin(UserGameObject, hostAppUser, true);
 	}
 
 	public void UserLeave()

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -138,10 +138,19 @@ namespace MixedRealityExtension.API
 		/// Creates a new mixed reality extension app and adds it to the MRE runtime.
 		/// </summary>
 		/// <param name="ownerScript">The owner unity script for the app.</param>
-		/// <param name="globalAppId">The global app id for the app being instanced, or empty if there is no global app id.</param>
-		/// <param name="ephemeralAppId">A string uniquely identifying the MRE instance on all clients.</param>
+		/// <param name="ephemeralAppId">A unique identifier for the MRE behind this instance's URL, in the absence
+		/// of a global app ID. Used for generating user IDs that are consistent within this session across clients,
+		/// but not reliable across time. Must be synchronized across all clients in this session, and must be
+		/// periodically rotated.</param>
+		/// <param name="globalAppId">A unique identifier for the MRE behind this instance's URL. Used for generating
+		/// consistent user IDs for this MRE. Would typically come from an app registry or similar. If supplied, must
+		/// be synchronized across all clients in this session.
+		/// </param>
 		/// <returns>Returns the newly created mixed reality extension app.</returns>
-		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(MonoBehaviour ownerScript, string ephemeralAppId, string globalAppId = "")
+		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(
+			MonoBehaviour ownerScript,
+			string ephemeralAppId,
+			string globalAppId = "")
 		{
 			var mreApp = new MixedRealityExtensionApp(globalAppId ?? string.Empty, ephemeralAppId, ownerScript)
 			{

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -139,11 +139,11 @@ namespace MixedRealityExtension.API
 		/// </summary>
 		/// <param name="ownerScript">The owner unity script for the app.</param>
 		/// <param name="globalAppId">The global app id for the app being instanced, or empty if there is no global app id.</param>
-		/// <param name="localAppId">A string uniquely identifying the MRE instance on all clients.</param>
+		/// <param name="ephemeralAppId">A string uniquely identifying the MRE instance on all clients.</param>
 		/// <returns>Returns the newly created mixed reality extension app.</returns>
-		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(MonoBehaviour ownerScript, string globalAppId = "", string localAppId = "")
+		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(MonoBehaviour ownerScript, string ephemeralAppId, string globalAppId = "")
 		{
-			var mreApp = new MixedRealityExtensionApp(globalAppId ?? string.Empty, localAppId, ownerScript)
+			var mreApp = new MixedRealityExtensionApp(globalAppId ?? string.Empty, ephemeralAppId, ownerScript)
 			{
 				InstanceId = Guid.NewGuid()
 			};

--- a/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/API/MREApi.cs
@@ -139,10 +139,11 @@ namespace MixedRealityExtension.API
 		/// </summary>
 		/// <param name="ownerScript">The owner unity script for the app.</param>
 		/// <param name="globalAppId">The global app id for the app being instanced, or empty if there is no global app id.</param>
+		/// <param name="localAppId">A string uniquely identifying the MRE instance on all clients.</param>
 		/// <returns>Returns the newly created mixed reality extension app.</returns>
-		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(MonoBehaviour ownerScript, string globalAppId = "")
+		public IMixedRealityExtensionApp CreateMixedRealityExtensionApp(MonoBehaviour ownerScript, string globalAppId = "", string localAppId = "")
 		{
-			var mreApp = new MixedRealityExtensionApp(globalAppId ?? string.Empty, ownerScript)
+			var mreApp = new MixedRealityExtensionApp(globalAppId ?? string.Empty, localAppId, ownerScript)
 			{
 				InstanceId = Guid.NewGuid()
 			};

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -67,6 +67,11 @@ namespace MixedRealityExtension.App
 		string GlobalAppId { get; }
 
 		/// <summary>
+		/// A string uniquely identifying the MRE instance, shared across all clients.
+		/// </summary>
+		string LocalAppId { get; }
+
+		/// <summary>
 		/// Gets the session id of the mixed reality extension app.
 		/// </summary>
 		string SessionId { get; }

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -52,14 +52,16 @@ namespace MixedRealityExtension.App
 		event MWEventHandler<IActor> OnActorCreated;
 
 		/// <summary>
-		/// Event that is raised when the local user joins the MRE application.
+		/// Event that is raised when the local user joins the MRE application. Is passed the user and a boolean
+		/// indicating whether the user joined from the local client, or from a remote client.
 		/// </summary>
-		event MWEventHandler<IUser> OnUserJoined;
+		event MWEventHandler<IUser, bool> OnUserJoined;
 
 		/// <summary>
-		/// Event that is raised when the local user leaves the MRE application.
+		/// Event that is raised when the local user leaves the MRE application. Is passed the user and a boolean
+		/// indicating whether the user left from the local client, or from a remote client.
 		/// </summary>
-		event MWEventHandler<IUser> OnUserLeft;
+		event MWEventHandler<IUser, bool> OnUserLeft;
 
 		/// <summary>
 		/// A string uniquely identifying the MRE behind the server URL. Used for generating consistent user IDs when

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -138,7 +138,8 @@ namespace MixedRealityExtension.App
 		/// </summary>
 		/// <param name="userGO">The game object that serves as the user in unity.</param>
 		/// <param name="hostAppUser">Interface for providing a representation of the host app user.</param>
-		void UserJoin(GameObject userGO, IHostAppUser hostAppUser);
+		/// <param name="isLocalUser">Indicates whether this user originates on this client, or is a local representation of a remote user.</param>
+		void UserJoin(GameObject userGO, IHostAppUser hostAppUser, bool isLocalUser);
 
 		/// <summary>
 		/// User is leaving the app.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -62,14 +62,16 @@ namespace MixedRealityExtension.App
 		event MWEventHandler<IUser> OnUserLeft;
 
 		/// <summary>
-		/// Gets the global id of the mixed reality extension app.
+		/// A string uniquely identifying the MRE behind the server URL. Used for generating consistent user IDs when
+		/// user tracking is enabled.
 		/// </summary>
 		string GlobalAppId { get; }
 
 		/// <summary>
-		/// A string uniquely identifying the MRE instance, shared across all clients.
+		/// A string uniquely identifying the MRE instance in the shared space across all clients. Used for generating
+		/// user IDs when user tracking is disabled.
 		/// </summary>
-		string LocalAppId { get; }
+		string EphemeralAppId { get; }
 
 		/// <summary>
 		/// Gets the session id of the mixed reality extension app.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -457,12 +457,13 @@ namespace MixedRealityExtension.App
 		}
 
 		/// <inheritdoc />
-		public void UserJoin(GameObject userGO, IHostAppUser hostAppUser)
+		public void UserJoin(GameObject userGO, IHostAppUser hostAppUser, bool isLocalUser)
 		{
 			void PerformUserJoin()
 			{
 				// only join the user if required
-				if (!GrantedPermissions.HasFlag(Permissions.UserInteraction)
+				if (isLocalUser
+					&& !GrantedPermissions.HasFlag(Permissions.UserInteraction)
 					&& !GrantedPermissions.HasFlag(Permissions.UserTracking))
 				{
 					return;
@@ -478,23 +479,26 @@ namespace MixedRealityExtension.App
 					user.Initialize(hostAppUser, GenerateObfuscatedUserId(hostAppUser), this);
 				}
 
-				Protocol.Send(new UserJoined()
-				{
-					User = new UserPatch(user)
-				});
-
-				LocalUser = user;
-
-				PhysicsBridge.LocalUserId = LocalUser.Id;
-
 				// TODO @tombu - Wait for the app to send back a success for join?
 				_userManager.AddUser(user);
 
-			// Enable interactions for the user if given the UserInteraction permission.
-			if (GrantedPermissions.HasFlag(Permissions.UserInteraction))
-			{
-				EnableUserInteraction(user);
-}
+				if (isLocalUser)
+				{
+					Protocol.Send(new UserJoined()
+					{
+						User = new UserPatch(user)
+					});
+
+					LocalUser = user;
+
+					PhysicsBridge.LocalUserId = LocalUser.Id;
+
+					// Enable interactions for the user if given the UserInteraction permission.
+					if (GrantedPermissions.HasFlag(Permissions.UserInteraction))
+					{
+						EnableUserInteraction(user);
+					}
+				}
 
 				OnUserJoined?.Invoke(user);
 			}

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -101,10 +101,10 @@ namespace MixedRealityExtension.App
 		}
 
 		/// <inheritdoc />
-		public event MWEventHandler<IUser> OnUserJoined;
+		public event MWEventHandler<IUser, bool> OnUserJoined;
 
 		/// <inheritdoc />
-		public event MWEventHandler<IUser> OnUserLeft;
+		public event MWEventHandler<IUser, bool> OnUserLeft;
 
 		#endregion
 
@@ -512,7 +512,7 @@ namespace MixedRealityExtension.App
 					}
 				}
 
-				OnUserJoined?.Invoke(user);
+				OnUserJoined?.Invoke(user, isLocalUser);
 			}
 
 			if (Protocol is Execution)
@@ -541,12 +541,15 @@ namespace MixedRealityExtension.App
 				_userManager.RemoveUser(user);
 				_interactingUserIds.Remove(user.Id);
 
-				if (Protocol is Execution)
+				var isLocalUser = user == LocalUser;
+				LocalUser = null;
+
+				if (isLocalUser && Protocol is Execution)
 				{
 					Protocol.Send(new UserLeft() { UserId = user.Id });
 				}
 
-				OnUserLeft?.Invoke(user);
+				OnUserLeft?.Invoke(user, isLocalUser);
 			}
 		}
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
@@ -23,13 +23,13 @@ namespace MixedRealityExtension.Core
 
 		public UInt32 Groups { get; internal set; } = 1;
 
-		public Guid InstancedUserId { get; private set; }
+		public Guid EphemeralUserId { get; private set; }
 
-		internal void Initialize(IHostAppUser hostAppUser, Guid userId, Guid instancedUserId, MixedRealityExtensionApp app)
+		internal void Initialize(IHostAppUser hostAppUser, Guid userId, Guid ephemeralUserId, MixedRealityExtensionApp app)
 		{
 			HostAppUser = hostAppUser;
 			base.Initialize(userId, app);
-			InstancedUserId = instancedUserId;
+			EphemeralUserId = ephemeralUserId;
 		}
 
 		internal void JoinApp(MixedRealityExtensionApp app)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/User.cs
@@ -23,10 +23,13 @@ namespace MixedRealityExtension.Core
 
 		public UInt32 Groups { get; internal set; } = 1;
 
-		internal void Initialize(IHostAppUser hostAppUser, Guid userId, MixedRealityExtensionApp app)
+		public Guid InstancedUserId { get; private set; }
+
+		internal void Initialize(IHostAppUser hostAppUser, Guid userId, Guid instancedUserId, MixedRealityExtensionApp app)
 		{
 			HostAppUser = hostAppUser;
 			base.Initialize(userId, app);
+			InstancedUserId = instancedUserId;
 		}
 
 		internal void JoinApp(MixedRealityExtensionApp app)

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/UserManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/UserManager.cs
@@ -21,6 +21,7 @@ namespace MixedRealityExtension.Core
 		internal void AddUser(User user)
 		{
 			_userMapping[user.Id] = user;
+			_userMapping[user.InstancedUserId] = user;
 			user.JoinApp(_app);
 		}
 

--- a/MREUnityRuntime/MREUnityRuntimeLib/Core/UserManager.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Core/UserManager.cs
@@ -21,7 +21,7 @@ namespace MixedRealityExtension.Core
 		internal void AddUser(User user)
 		{
 			_userMapping[user.Id] = user;
-			_userMapping[user.InstancedUserId] = user;
+			_userMapping[user.EphemeralUserId] = user;
 			user.JoinApp(_app);
 		}
 
@@ -29,6 +29,7 @@ namespace MixedRealityExtension.Core
 		{
 			user.LeaveApp(_app);
 			_userMapping.Remove(user.Id);
+			_userMapping.Remove(user.EphemeralUserId);
 		}
 
 		internal User FindUser(Guid userId)

--- a/MREUnityRuntime/MREUnityRuntimeLib/IPC/IConnection.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/IPC/IConnection.cs
@@ -18,6 +18,15 @@ namespace MixedRealityExtension.IPC
 	public delegate void MWEventHandler<ArgsT>(ArgsT args);
 
 	/// <summary>
+	/// Event handler type with two arguments.
+	/// </summary>
+	/// <typeparam name="ArgsT"></typeparam>
+	/// <typeparam name="ArgsU"></typeparam>
+	/// <param name="arg1"></param>
+	/// <param name="arg2"></param>
+	public delegate void MWEventHandler<ArgsT, ArgsU>(ArgsT arg1, ArgsU arg2);
+
+	/// <summary>
 	/// The set of possible reason codes passed to the OnConnectFailed event.
 	/// </summary>
 	public enum ConnectFailedReason


### PR DESCRIPTION
* In #216 we accidentally removed the ability to attach things to anyone but the local user. We removed the `UserInfoProvider`, and replaced it with an `IHostAppUser` that provides the attach points. These host app users are provided to the runtime through `IMixedRealityApp.UserJoin`.
* I have added an `isLocalUser` boolean argument to that method so host app user objects for non-local users can also be passed in. This changes the convention of only local users calling UserJoin; now UserJoin should be called for all users that the client knows about.
* For non-local users on a client, we now compute both the AppId-based user ID and also the EphemeralAppId-based ID for the purposes of looking up attachments, since we don't know which one the user is going by.