### PR TITLE
Fix for deadlock on cleanup in Mac OS host apps

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/IPC/Connections/WebSocket.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/IPC/Connections/WebSocket.cs
@@ -428,7 +428,7 @@ namespace MixedRealityExtension.IPC.Connections
 			if (!disposed)
 			{
 				disposed = true;
-				Task.Run(() => CloseInternal(false, "Dispose")).Wait();
+				Task.Run(() => CloseInternal(true, "Dispose")).Wait();
 				Task.Run(() => DisposeInternal()).Wait();
 			}
 		}


### PR DESCRIPTION
Fix an issue during cleanup of the websocket where on Mac OS, the close output only on the websocket does not cause the cancellation of the awaiting read task.