### PR TITLE
Fix asset refcounting issues when server doesn't provide etags

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -173,7 +173,7 @@ namespace MixedRealityExtension.Assets
 			{
 				// set up loader
 				loader = new WebRequestLoader(rootUri);
-				if (!string.IsNullOrEmpty(cachedVersion))
+				if (cachedVersion != Constants.UnversionedAssetVersion && !string.IsNullOrEmpty(cachedVersion))
 				{
 					loader.BeforeRequestCallback += (msg) =>
 					{
@@ -188,7 +188,7 @@ namespace MixedRealityExtension.Assets
 				try
 				{
 					stream = await loader.LoadStreamAsync(URIHelper.GetFileFromUri(source.ParsedUri));
-					source.Version = loader.LastResponse.Headers.ETag?.Tag ?? "";
+					source.Version = loader.LastResponse.Headers.ETag?.Tag ?? Constants.UnversionedAssetVersion;
 				}
 				catch (HttpRequestException)
 				{

--- a/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Constants.cs
@@ -61,5 +61,10 @@ namespace MixedRealityExtension
 		 * It is NOT compatibile with SDK versions older than 0.19.
 		 */
 		internal const bool UsePhysicsBridge = true;
+
+		/// <summary>
+		/// If we load an asset, and the server response does not contain an ETag, this is the asset's version
+		/// </summary>
+		internal const string UnversionedAssetVersion = "unversioned";
 	}
 }


### PR DESCRIPTION
If the asset server is not providing `ETag` headers with its responses, assume cached assets are always fresh.