### PR TITLE
Fixed a null deref when last response is null

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/Assets/AssetLoader.cs
@@ -192,7 +192,8 @@ namespace MixedRealityExtension.Assets
 				}
 				catch (HttpRequestException)
 				{
-					if (loader.LastResponse.StatusCode == System.Net.HttpStatusCode.NotModified)
+					if (loader.LastResponse != null
+						&& loader.LastResponse.StatusCode == System.Net.HttpStatusCode.NotModified)
 					{
 						source.Version = cachedVersion;
 					}


### PR DESCRIPTION
Absent this change, some types of failures are masked by a null pointer deref