### PR TITLE
Add new app events OnWaitingForPermission and OnPermissionDenied

### DIFF
--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -17,6 +17,11 @@ namespace MixedRealityExtension.App
 	public interface IMixedRealityExtensionApp
 	{
 		/// <summary>
+		/// Event that is raised just before this app makes its permissions request to the <see cref="IPermissionManager"/>.
+		/// </summary>
+		event MWEventHandler OnWaitingForPermission;
+
+		/// <summary>
 		/// Event that is raised when the mixed reality extension app has connected to the app.
 		/// </summary>
 		event MWEventHandler OnConnecting;

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -141,10 +141,7 @@ namespace MixedRealityExtension.App
 		/// <summary>
 		/// Called to shut down the engine mixed reality extension app by the app process.
 		/// </summary>
-		/// <param name="restartOnPermissionGrant">If true, the MRE will <see cref="Startup(string, string)"/>
-		/// itself if its required permissions are granted. Only applies after <see cref="Startup(string, string)"/>
-		/// has been called explicitly at least once.</param>
-		void Shutdown(bool restartOnPermissionGrant = false);
+		void Shutdown();
 
 		/// <summary>
 		/// Update keyframed rigid bodies.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/IMixedRealityExtensionApp.cs
@@ -22,6 +22,12 @@ namespace MixedRealityExtension.App
 		event MWEventHandler OnWaitingForPermission;
 
 		/// <summary>
+		/// Event that is raised when a permission required to run the app is denied by the host. Will be immediately
+		/// followed by <see cref="OnAppShutdown"/>.
+		/// </summary>
+		event MWEventHandler OnPermissionDenied;
+
+		/// <summary>
 		/// Event that is raised when the mixed reality extension app has connected to the app.
 		/// </summary>
 		event MWEventHandler OnConnecting;
@@ -135,7 +141,10 @@ namespace MixedRealityExtension.App
 		/// <summary>
 		/// Called to shut down the engine mixed reality extension app by the app process.
 		/// </summary>
-		void Shutdown();
+		/// <param name="restartOnPermissionGrant">If true, the MRE will <see cref="Startup(string, string)"/>
+		/// itself if its required permissions are granted. Only applies after <see cref="Startup(string, string)"/>
+		/// has been called explicitly at least once.</param>
+		void Shutdown(bool restartOnPermissionGrant = false);
 
 		/// <summary>
 		/// Update keyframed rigid bodies.

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -272,7 +272,8 @@ namespace MixedRealityExtension.App
 
 			MREAPI.AppsAPI.PermissionManager.OnPermissionDecisionsChanged += OnPermissionsUpdated;
 
-			if (!grantedPerms.HasFlag(Permissions.Execution))
+			// make sure all needed perms are granted
+			if ((neededFlags & GrantedPermissions) != neededFlags)
 			{
 				Debug.LogError($"User has denied permission for the MRE '{ServerUri}' to run");
 				return;

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -79,6 +79,9 @@ namespace MixedRealityExtension.App
 		public event MWEventHandler OnWaitingForPermission;
 
 		/// <inheritdoc />
+		public event MWEventHandler OnPermissionDenied;
+
+		/// <inheritdoc />
 		public event MWEventHandler OnConnecting;
 
 		/// <inheritdoc />
@@ -276,6 +279,8 @@ namespace MixedRealityExtension.App
 			if ((neededFlags & GrantedPermissions) != neededFlags)
 			{
 				Debug.LogError($"User has denied permission for the MRE '{ServerUri}' to run");
+				OnPermissionDenied?.Invoke();
+				Shutdown(restartOnPermissionGrant: true);
 				return;
 			}
 
@@ -336,12 +341,15 @@ namespace MixedRealityExtension.App
 		}
 
 		/// <inheritdoc />
-		public void Shutdown()
+		public void Shutdown(bool restartOnPermissionGrant = false)
 		{
 			Disconnect();
 			FreeResources();
 
-			MREAPI.AppsAPI.PermissionManager.OnPermissionDecisionsChanged -= OnPermissionsUpdated;
+			if (restartOnPermissionGrant)
+			{
+				MREAPI.AppsAPI.PermissionManager.OnPermissionDecisionsChanged -= OnPermissionsUpdated;
+			}
 
 			if (_appState != AppState.Stopped)
 			{

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -76,6 +76,9 @@ namespace MixedRealityExtension.App
 		#region Events - Public
 
 		/// <inheritdoc />
+		public event MWEventHandler OnWaitingForPermission;
+
+		/// <inheritdoc />
 		public event MWEventHandler OnConnecting;
 
 		/// <inheritdoc />
@@ -234,6 +237,7 @@ namespace MixedRealityExtension.App
 			SessionId = sessionId;
 
 			_appState = AppState.WaitingForPermission;
+			OnWaitingForPermission?.Invoke();
 
 			// download manifest
 			var manifestUri = new Uri(ServerAssetUri, "./manifest.json");

--- a/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
+++ b/MREUnityRuntime/MREUnityRuntimeLib/App/MixedRealityExtensionApp.cs
@@ -254,7 +254,7 @@ namespace MixedRealityExtension.App
 				Debug.LogErrorFormat("Error downloading MRE manifest \"{0}\":\n{1}", manifestUri, e.ToString());
 				manifest = new AppManifest()
 				{
-					OptionalPermissions = new Permissions[] { Permissions.UserTracking, Permissions.UserInteraction }
+					Permissions = new Permissions[] { Permissions.UserTracking, Permissions.UserInteraction }
 				};
 			}
 


### PR DESCRIPTION
Also: update the permission requests so that if an app doesn't supply a manifest, the runtime assumes it requires both tracking and interaction.